### PR TITLE
Allow default content to be exported and updated contributing documentation

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,47 @@
+# Contributing Guidelines
+
+### Contents
+
+- [Getting Starting](#getting-starting)
+- [Git](#git)
+- [Content](#content)
+- [Validation](#validation)
+
+## Getting Started
+
+To get started with a local environment, please see the Wiki for the [Drupal Env Lando](https://github.com/mattsqd/drupal-env-lando/wiki) project.
+
+TLDR:
+* This is just a lando site, all lando commands are available.
+* First time: `./robo.sh lando:init`
+* Starting Lando: `lando start`
+* Installing a Drupal site from config (no DB needed): `lando si`
+* See a list of shortcuts (Drush, Composer, etc.): `./robo.sh common:shortcuts-help`
+* Make sure that you use `./composer.sh` instead of `composer` or `lando composer`. `./composer.sh` will cause entries `composer.log` to be made so we can replay composer commands on conflicts.
+* Sign in as admin: `./drush uli`
+
+## Git
+
+To have your commits merged in GitHub, you must have [verified commits](https://docs.github.com/en/authentication/managing-commit-signature-verification/about-commit-signature-verification#ssh-commit-signature-verification). If you forget to do this for a MR, you will need to rebase/replay your commits.
+
+## Content
+
+The content for development is created via the [Default Content](https://www.drupal.org/project/default_content) module.
+
+How do I install the content?
+
+Content is created from the config stored at `web/modules/custom/default_content_config/content` when the site is installed.
+
+How do I create more content?
+
+Simply edit or add new content, then run `./robo.sh drupal-project:export-content`
+
+:exclamation: Make sure that only content you meant to edit or add is exported. The default content module is not perfect, it can get confused with things like files and users.
+
+## Validation
+
+We will soon have validation on branches, commits, composer.lock, and code. I'm waiting until our move to Jira.
+
+To start:
+* Follow Drupal & DrupalPractice coding standards.
+* Create feature branches in the form `feature/short-description`

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # Digital.gov (Drupal)
 
-## Contributing
+Welcome to the Digital.gov Drupal site.
 
-To get started with a local environment, please see the Wiki for the [Drupal Env Lando](https://github.com/mattsqd/drupal-env-lando/wiki) project.
+See our [CONTRIBUTING.md](CONTRIBUTING.md).
+
+

--- a/RoboFile.php
+++ b/RoboFile.php
@@ -1,5 +1,6 @@
 <?php
 
+use Robo\ResultData;
 use Robo\Tasks;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
@@ -29,5 +30,45 @@ class RoboFile extends Tasks
         $io = new SymfonyStyle($input, $output);
         $io->comment('This is just a placeholder command, please add your own custom commands here. Please edit : ' . __FILE__);
     }
+
+    /**
+     * Export default content.
+     *
+     * @command drupal-project:export-content
+     *
+     * @return \Robo\ResultData
+     *
+     * @throws \Exception
+     */
+    public function exportContent(
+        InputInterface $input,
+        OutputInterface $output,
+        array $opts = [
+            'path' => 'modules/custom/default_content_config',
+            'entities' => [
+                'node',
+                'menu_link_content',
+                'media',
+            ],
+        ]
+    ): ResultData
+    {
+
+        $path =  $opts['path'];
+        $entities = $opts['entities'];
+        $io = new SymfonyStyle($input, $output);
+        if (is_dir("web/$path/content")) {
+            $io->info('Removing existing default content exported.');
+            $this->_cleanDir("web/$path/content");
+        }
+        foreach ($entities as $entity) {
+            $io->info("Exporting $entity as default content");
+            $this->_exec("./drush.sh default-content:export-references $entity --folder=$path/content");
+        }
+        $io->info("Finished exporting default content to $path/content");
+
+        return new ResultData();
+    }
+
 
 }

--- a/composer.json
+++ b/composer.json
@@ -23,6 +23,7 @@
         "drupal/core-composer-scaffold": "^10.2",
         "drupal/core-project-message": "^10.2",
         "drupal/core-recommended": "^10.2",
+        "drupal/default_content": "^2.0@alpha",
         "drupal/field_permissions": "^1.3",
         "drupal/linkit": "^6.1",
         "drupal/maillog": "dev-1.x",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "bb2ce4b6d0815fc37546055a9eed9011",
+    "content-hash": "286e99c697432ec5c9f9e95bc4e97c27",
     "packages": [
         {
             "name": "asm89/stack-cors",
@@ -1785,6 +1785,83 @@
                 "source": "https://github.com/drupal/core-recommended/tree/10.3.5"
             },
             "time": "2024-09-12T09:45:37+00:00"
+        },
+        {
+            "name": "drupal/default_content",
+            "version": "2.0.0-alpha3",
+            "source": {
+                "type": "git",
+                "url": "https://git.drupalcode.org/project/default_content.git",
+                "reference": "2.0.0-alpha3"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://ftp.drupal.org/files/projects/default_content-2.0.0-alpha3.zip",
+                "reference": "2.0.0-alpha3",
+                "shasum": "fdd90c70bd91896835f6ba5ec42c260c1a144a2b"
+            },
+            "require": {
+                "drupal/core": "^9.1 || ^10 || ^11"
+            },
+            "require-dev": {
+                "drupal/hal": "^1 || ^2",
+                "drupal/paragraphs": "^1"
+            },
+            "type": "drupal-module",
+            "extra": {
+                "drupal": {
+                    "version": "2.0.0-alpha3",
+                    "datestamp": "1724492420",
+                    "security-coverage": {
+                        "status": "not-covered",
+                        "message": "Alpha releases are not covered by Drupal security advisories."
+                    }
+                },
+                "drush": {
+                    "services": {
+                        "drush.services.yml": "^9 || ^10 || ^11 || ^12"
+                    }
+                }
+            },
+            "notification-url": "https://packages.drupal.org/8/downloads",
+            "license": [
+                "GPL-2.0+"
+            ],
+            "authors": [
+                {
+                    "name": "andypost",
+                    "homepage": "https://www.drupal.org/user/118908"
+                },
+                {
+                    "name": "benjy",
+                    "homepage": "https://www.drupal.org/user/1852732"
+                },
+                {
+                    "name": "berdir",
+                    "homepage": "https://www.drupal.org/user/214652"
+                },
+                {
+                    "name": "dawehner",
+                    "homepage": "https://www.drupal.org/user/99340"
+                },
+                {
+                    "name": "jibran",
+                    "homepage": "https://www.drupal.org/user/1198144"
+                },
+                {
+                    "name": "larowlan",
+                    "homepage": "https://www.drupal.org/user/395439"
+                },
+                {
+                    "name": "sam152",
+                    "homepage": "https://www.drupal.org/user/1485048"
+                }
+            ],
+            "description": "Imports default content when a module is enabled",
+            "homepage": "https://www.drupal.org/project/default_content",
+            "support": {
+                "source": "https://git.drupalcode.org/project/default_content"
+            }
         },
         {
             "name": "drupal/field_permissions",
@@ -12951,6 +13028,7 @@
     "aliases": [],
     "minimum-stability": "stable",
     "stability-flags": {
+        "drupal/default_content": 15,
         "drupal/maillog": 20,
         "drupal/scheduler_content_moderation_integration": 10,
         "drupal/uswds_templates": 20,

--- a/composer.log
+++ b/composer.log
@@ -14,3 +14,4 @@ ae2759e9c45acbf0d8378d04e842d0a8|Matt Poole|develop|Tue Jul  2 13:45:43 EDT 2024
 579caa649444081ab37a8552cdd0411e|Matt Poole|feature/update-deps|Thu Sep 26 10:10:52 EDT 2024|./composer.sh require mattsqd/drupal-env:dev-main
 3b53a72eee437f256a7c519f1cbbacdb|Matt Poole|feature/update-deps|Thu Sep 26 10:11:13 EDT 2024|./composer.sh require mattsqd/drupal-env-lando:dev-main
 51b1db8a23eabb3f084cd6f4caac2351|Matt Poole|feature/update-deps|Thu Sep 26 10:14:06 EDT 2024|./composer.sh update
+988761caf540bfc9c7d6bdb1d884208d|Matt Poole|feature/default-content|Fri Sep 27 13:52:06 EDT 2024|./composer.sh require drupal/default_content:^2.0@alpha

--- a/composer.patches.json
+++ b/composer.patches.json
@@ -3,6 +3,10 @@
     "drupal/core-composer-scaffold": {
       "Disable drupal/core from scaffolding without being in composer.extra.drupal-scaffold.allowed-packages in that way one has more control of when new scaffolding is added.": "./patches/drupal.core-composer-scaffold.implicit-drupal-core-disable.patch"
     },
+    "drupal/default_content": {
+      "/project/default_content/issues/2698425:: Do not reimport existing entities (patch download b/c of it being from an MR)": "patches/deafult_content_2698425.patch",
+      "/project/default_content/issues/3203014: BaseFieldOverride cause inconsistencies during export": "https://www.drupal.org/files/issues/2022-12-13/base_field_override_inconsistencies-3203014-9.patch"
+    },
     "drupal/maillog": {
       "/project/maillog/issues/3176023: Not configurable sender and other issues.": "https://www.drupal.org/files/issues/2024-07-24/maillog-n3176023-9.patch"
     }

--- a/config/sync/core.extension.yml
+++ b/config/sync/core.extension.yml
@@ -13,6 +13,7 @@ module:
   content_moderation_notifications: 0
   datetime: 0
   dblog: 0
+  default_content: 0
   devel: 0
   dynamic_page_cache: 0
   ec_placeholder: 0
@@ -33,6 +34,8 @@ module:
   media: 0
   media_library: 0
   memcache: 0
+  menu_link_content: 0
+  menu_ui: 0
   mysql: 0
   node: 0
   options: 0

--- a/config/sync/menu_ui.settings.yml
+++ b/config/sync/menu_ui.settings.yml
@@ -1,0 +1,3 @@
+_core:
+  default_config_hash: SqMarzIjxC3F8dZo9FEOxfqDKD_sdW1tbcFTV1BA2zU
+override_parent_selector: false

--- a/patches/deafult_content_2698425.patch
+++ b/patches/deafult_content_2698425.patch
@@ -1,0 +1,1032 @@
+From 83fe76a56481ab6b429c8ca615c55f80e490c568 Mon Sep 17 00:00:00 2001
+From: EduardoMorales <EduardoMadrid@3546420.no-reply.drupal.org>
+Date: Wed, 20 Jan 2021 14:44:55 +0100
+Subject: [PATCH 1/9] Issue #2698425 by kalpaitch, das-peter, jts86, andreyks,
+ andypost, timmillwood, Karsa, robert-os, RumyanaRuseva, lammensj, e0ipso,
+ morsok, r.nabiullin, Yaron Tal, plopesc, jamedina97, diegodalr3, robpowell,
+ saramato, larowlan, eelkeblok, Manuel Garcia, vijaycs85, keesje, yannisc,
+ chr.fritsch, ao2, youfei.sun, agentrickard, neclimdul, SocialNicheGuru,
+ getu-lar: Do not reimport existing entities
+
+---
+ drush.services.yml                         |  2 +-
+ drush/default_content.drush.inc            | 21 +++++++++++++++++
+ src/Commands/DefaultContentCommands.php    | 26 +++++++++++++++++++++-
+ src/Importer.php                           |  5 ++++-
+ src/Normalizer/ContentEntityNormalizer.php | 10 ++++++++-
+ 5 files changed, 60 insertions(+), 4 deletions(-)
+
+diff --git a/drush.services.yml b/drush.services.yml
+index 441ae0c..cd94f1c 100644
+--- a/drush.services.yml
++++ b/drush.services.yml
+@@ -1,6 +1,6 @@
+ services:
+   default_content.commands:
+     class: \Drupal\default_content\Commands\DefaultContentCommands
+-    arguments: ['@default_content.exporter']
++    arguments: ['@default_content.exporter', '@default_content.importer']
+     tags:
+       - { name: drush.command }
+diff --git a/src/Commands/DefaultContentCommands.php b/src/Commands/DefaultContentCommands.php
+index d9c6da4..9820f2a 100644
+--- a/src/Commands/DefaultContentCommands.php
++++ b/src/Commands/DefaultContentCommands.php
+@@ -3,6 +3,7 @@
+ namespace Drupal\default_content\Commands;
+
+ use Drupal\default_content\ExporterInterface;
++use Drupal\default_content\ImporterInterface;
+ use Drush\Commands\DrushCommands;
+
+ /**
+@@ -19,14 +20,24 @@ class DefaultContentCommands extends DrushCommands {
+    */
+   protected $defaultContentExporter;
+
++  /**
++   * The default content importer.
++   *
++   * @var \Drupal\default_content\ImporterInterface
++   */
++  protected $defaultContentImporter;
++
+   /**
+    * SimplesitemapController constructor.
+    *
+    * @param \Drupal\default_content\ExporterInterface $default_content_exporter
+    *   The default content exporter.
++   * @param \Drupal\default_content\ImporterInterface $default_content_importer
++   *   The default content importer.
+    */
+-  public function __construct(ExporterInterface $default_content_exporter) {
++  public function __construct(ExporterInterface $default_content_exporter, ImporterInterface $default_content_importer) {
+     $this->defaultContentExporter = $default_content_exporter;
++    $this->defaultContentImporter = $default_content_importer;
+   }
+
+   /**
+@@ -91,4 +102,17 @@ class DefaultContentCommands extends DrushCommands {
+     $this->defaultContentExporter->exportModuleContent($module, $module_folder);
+   }
+
++  /**
++   * Imports all the content defined in a module info file.
++   *
++   * @param string $module
++   *   The name of the module.
++   *
++   * @command default-content:import-module
++   * @aliases dcim
++   */
++  public function contentImportModule($module) {
++    $this->defaultContentImporter->importContent($module);
++  }
++
+ }
+diff --git a/src/Importer.php b/src/Importer.php
+index e062781..9adeac1 100644
+--- a/src/Importer.php
++++ b/src/Importer.php
+@@ -225,7 +225,10 @@ class Importer implements ImporterInterface {
+             $entity = $this->contentEntityNormalizer->denormalize(Yaml::decode($contents));
+           }
+
+-          $entity->enforceIsNew(TRUE);
++          if (empty($entity)) {
++            continue;
++          }
++
+           // Ensure that the entity is not owned by the anonymous user.
+           if ($entity instanceof EntityOwnerInterface && empty($entity->getOwnerId())) {
+             $entity->setOwner($root_user);
+diff --git a/src/Normalizer/ContentEntityNormalizer.php b/src/Normalizer/ContentEntityNormalizer.php
+index 08d68ee..12a1076 100644
+--- a/src/Normalizer/ContentEntityNormalizer.php
++++ b/src/Normalizer/ContentEntityNormalizer.php
+@@ -178,8 +178,15 @@ class ContentEntityNormalizer implements ContentEntityNormalizerInterface {
+       $values[$entity_type->getKey('langcode')] = $data['_meta']['default_langcode'];
+     }
+
++    // Load the entity by UUID and check if it exists.
+     /** @var \Drupal\Core\Entity\ContentEntityInterface $entity */
+-    $entity = $this->entityTypeManager->getStorage($entity_type->id())->create($values);
++    $entity = $this->entityTypeManager->getStorage($entity_type->id())->loadByProperties(['uuid' => $values['uuid']]);
++    $entity = reset($entity);
++    $exists = !empty($entity);
++    if (!$exists) {
++      $entity = $this->entityTypeManager->getStorage($entity_type->id())->create($values);
++    }
++
+     foreach ($data['default'] as $field_name => $values) {
+       $this->setFieldValues($entity, $field_name, $values);
+     }
+@@ -518,3 +525,4 @@ class ContentEntityNormalizer implements ContentEntityNormalizerInterface {
+   }
+
+ }
++
+--
+GitLab
+
+
+From aef17d6c6a2d3e2cab6f25c0819539546ec7172e Mon Sep 17 00:00:00 2001
+From: Fabian Bircher <f.bircher@gmail.com>
+Date: Thu, 2 Dec 2021 12:02:16 +0100
+Subject: [PATCH 2/9] Do not update existing entities
+
+---
+ src/Normalizer/ContentEntityNormalizer.php | 12 +++++++-----
+ 1 file changed, 7 insertions(+), 5 deletions(-)
+
+diff --git a/src/Normalizer/ContentEntityNormalizer.php b/src/Normalizer/ContentEntityNormalizer.php
+index 12a1076..f59fd6c 100644
+--- a/src/Normalizer/ContentEntityNormalizer.php
++++ b/src/Normalizer/ContentEntityNormalizer.php
+@@ -179,14 +179,16 @@ class ContentEntityNormalizer implements ContentEntityNormalizerInterface {
+     }
+
+     // Load the entity by UUID and check if it exists.
++    $existing = $this->entityTypeManager->getStorage($entity_type->id())->loadByProperties(['uuid' => $values['uuid']]);
+     /** @var \Drupal\Core\Entity\ContentEntityInterface $entity */
+-    $entity = $this->entityTypeManager->getStorage($entity_type->id())->loadByProperties(['uuid' => $values['uuid']]);
+-    $entity = reset($entity);
+-    $exists = !empty($entity);
+-    if (!$exists) {
+-      $entity = $this->entityTypeManager->getStorage($entity_type->id())->create($values);
++    if (!empty($existing)) {
++      // Do not override the existing entity.
++      return reset($existing);
+     }
+
++    $entity = $this->entityTypeManager->getStorage($entity_type->id())->create($values);
++    $entity->enforceIsNew(TRUE);
++
+     foreach ($data['default'] as $field_name => $values) {
+       $this->setFieldValues($entity, $field_name, $values);
+     }
+--
+GitLab
+
+
+From 70943dd0578b1b4ab4a0b937dfc88efe3919e768 Mon Sep 17 00:00:00 2001
+From: Fabian Bircher <f.bircher@gmail.com>
+Date: Thu, 2 Dec 2021 12:10:49 +0100
+Subject: [PATCH 3/9] Skip updating entities which are not new
+
+---
+ src/Importer.php | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/src/Importer.php b/src/Importer.php
+index 9adeac1..89e567e 100644
+--- a/src/Importer.php
++++ b/src/Importer.php
+@@ -225,7 +225,7 @@ class Importer implements ImporterInterface {
+             $entity = $this->contentEntityNormalizer->denormalize(Yaml::decode($contents));
+           }
+
+-          if (empty($entity)) {
++          if (!$entity->isNew()) {
+             continue;
+           }
+
+--
+GitLab
+
+
+From 4ba12a9a3491e64743659002d144a27ab6dc5816 Mon Sep 17 00:00:00 2001
+From: Fabian Bircher <f.bircher@gmail.com>
+Date: Thu, 2 Dec 2021 12:51:09 +0100
+Subject: [PATCH 4/9] Remove drush command changes
+
+---
+ drush.services.yml                         |  2 +-
+ drush/default_content.drush.inc            | 21 -----------------
+ src/Commands/DefaultContentCommands.php    | 26 +---------------------
+ src/Normalizer/ContentEntityNormalizer.php |  1 -
+ 4 files changed, 2 insertions(+), 48 deletions(-)
+
+diff --git a/drush.services.yml b/drush.services.yml
+index cd94f1c..441ae0c 100644
+--- a/drush.services.yml
++++ b/drush.services.yml
+@@ -1,6 +1,6 @@
+ services:
+   default_content.commands:
+     class: \Drupal\default_content\Commands\DefaultContentCommands
+-    arguments: ['@default_content.exporter', '@default_content.importer']
++    arguments: ['@default_content.exporter']
+     tags:
+       - { name: drush.command }
+diff --git a/src/Commands/DefaultContentCommands.php b/src/Commands/DefaultContentCommands.php
+index 9820f2a..d9c6da4 100644
+--- a/src/Commands/DefaultContentCommands.php
++++ b/src/Commands/DefaultContentCommands.php
+@@ -3,7 +3,6 @@
+ namespace Drupal\default_content\Commands;
+
+ use Drupal\default_content\ExporterInterface;
+-use Drupal\default_content\ImporterInterface;
+ use Drush\Commands\DrushCommands;
+
+ /**
+@@ -20,24 +19,14 @@ class DefaultContentCommands extends DrushCommands {
+    */
+   protected $defaultContentExporter;
+
+-  /**
+-   * The default content importer.
+-   *
+-   * @var \Drupal\default_content\ImporterInterface
+-   */
+-  protected $defaultContentImporter;
+-
+   /**
+    * SimplesitemapController constructor.
+    *
+    * @param \Drupal\default_content\ExporterInterface $default_content_exporter
+    *   The default content exporter.
+-   * @param \Drupal\default_content\ImporterInterface $default_content_importer
+-   *   The default content importer.
+    */
+-  public function __construct(ExporterInterface $default_content_exporter, ImporterInterface $default_content_importer) {
++  public function __construct(ExporterInterface $default_content_exporter) {
+     $this->defaultContentExporter = $default_content_exporter;
+-    $this->defaultContentImporter = $default_content_importer;
+   }
+
+   /**
+@@ -102,17 +91,4 @@ class DefaultContentCommands extends DrushCommands {
+     $this->defaultContentExporter->exportModuleContent($module, $module_folder);
+   }
+
+-  /**
+-   * Imports all the content defined in a module info file.
+-   *
+-   * @param string $module
+-   *   The name of the module.
+-   *
+-   * @command default-content:import-module
+-   * @aliases dcim
+-   */
+-  public function contentImportModule($module) {
+-    $this->defaultContentImporter->importContent($module);
+-  }
+-
+ }
+diff --git a/src/Normalizer/ContentEntityNormalizer.php b/src/Normalizer/ContentEntityNormalizer.php
+index f59fd6c..d451b5d 100644
+--- a/src/Normalizer/ContentEntityNormalizer.php
++++ b/src/Normalizer/ContentEntityNormalizer.php
+@@ -527,4 +527,3 @@ class ContentEntityNormalizer implements ContentEntityNormalizerInterface {
+   }
+
+ }
+-
+--
+GitLab
+
+
+From f8dde94c3c5dc5cfd793c25434e9f1e448b5ec21 Mon Sep 17 00:00:00 2001
+From: Pieter Frenssen <pieter@frenssen.be>
+Date: Thu, 10 Nov 2022 11:43:17 +0200
+Subject: [PATCH 5/9] Introduce a flag to update or ignore existing content.
+
+---
+ src/Importer.php                                 |  4 ++--
+ src/ImporterInterface.php                        |  5 ++++-
+ src/Normalizer/ContentEntityNormalizer.php       | 16 ++++++++++------
+ .../ContentEntityNormalizerInterface.php         |  5 ++++-
+ 4 files changed, 20 insertions(+), 10 deletions(-)
+
+diff --git a/src/Importer.php b/src/Importer.php
+index 320a38f..c9d3734 100644
+--- a/src/Importer.php
++++ b/src/Importer.php
+@@ -149,7 +149,7 @@ class Importer implements ImporterInterface {
+   /**
+    * {@inheritdoc}
+    */
+-  public function importContent($module) {
++  public function importContent($module, bool $update_existing = FALSE) {
+     $created = [];
+     $folder = \Drupal::service('extension.list.module')->getPath($module) . "/content";
+
+@@ -251,7 +251,7 @@ class Importer implements ImporterInterface {
+             $entity = $this->serializer->deserialize($contents, $class, 'hal_json', ['request_method' => 'POST']);
+           }
+           else {
+-            $entity = $this->contentEntityNormalizer->denormalize(Yaml::decode($contents));
++            $entity = $this->contentEntityNormalizer->denormalize(Yaml::decode($contents), $update_existing);
+           }
+
+           if (!$entity->isNew()) {
+diff --git a/src/ImporterInterface.php b/src/ImporterInterface.php
+index 0d300a3..25fdcac 100644
+--- a/src/ImporterInterface.php
++++ b/src/ImporterInterface.php
+@@ -12,10 +12,13 @@ interface ImporterInterface {
+    *
+    * @param string $module
+    *   The module to create the default content from.
++   * @param bool $update_existing
++   *   Whether to update already existing entities with the imported values.
++   *   Defaults to FALSE.
+    *
+    * @return \Drupal\Core\Entity\EntityInterface[]
+    *   An array of created entities keyed by their UUIDs.
+    */
+-  public function importContent($module);
++  public function importContent($module, bool $update_existing = FALSE);
+
+ }
+diff --git a/src/Normalizer/ContentEntityNormalizer.php b/src/Normalizer/ContentEntityNormalizer.php
+index afc0d4b..86108d1 100644
+--- a/src/Normalizer/ContentEntityNormalizer.php
++++ b/src/Normalizer/ContentEntityNormalizer.php
+@@ -150,7 +150,7 @@ class ContentEntityNormalizer implements ContentEntityNormalizerInterface {
+   /**
+    * {@inheritdoc}
+    */
+-  public function denormalize(array $data) {
++  public function denormalize(array $data, bool $update_existing = FALSE) {
+     if (!isset($data['_meta']['entity_type'])) {
+       throw new UnexpectedValueException('The entity type metadata must be specified.');
+     }
+@@ -182,12 +182,16 @@ class ContentEntityNormalizer implements ContentEntityNormalizerInterface {
+     $existing = $this->entityTypeManager->getStorage($entity_type->id())->loadByProperties(['uuid' => $values['uuid']]);
+     /** @var \Drupal\Core\Entity\ContentEntityInterface $entity */
+     if (!empty($existing)) {
+-      // Do not override the existing entity.
+-      return reset($existing);
++      $entity = reset($existing);
++      if (!$update_existing) {
++        // Do not override the existing entity.
++        return $entity;
++      }
++    }
++    else {
++      $entity = $this->entityTypeManager->getStorage($entity_type->id())->create($values);
++      $entity->enforceIsNew(TRUE);
+     }
+-
+-    $entity = $this->entityTypeManager->getStorage($entity_type->id())->create($values);
+-    $entity->enforceIsNew(TRUE);
+
+     foreach ($data['default'] as $field_name => $values) {
+       $this->setFieldValues($entity, $field_name, $values);
+diff --git a/src/Normalizer/ContentEntityNormalizerInterface.php b/src/Normalizer/ContentEntityNormalizerInterface.php
+index fa78b79..1587248 100644
+--- a/src/Normalizer/ContentEntityNormalizerInterface.php
++++ b/src/Normalizer/ContentEntityNormalizerInterface.php
+@@ -27,10 +27,13 @@ interface ContentEntityNormalizerInterface {
+    *
+    * @param array $data
+    *   The normalized data.
++   * @param bool $update_existing
++   *   Whether to update an already existing entity with the imported values.
++   *   Defaults to FALSE.
+    *
+    * @return \Drupal\Core\Entity\ContentEntityInterface
+    *   The denormalized content entity.
+    */
+-  public function denormalize(array $data);
++  public function denormalize(array $data, bool $update_existing = FALSE);
+
+ }
+--
+GitLab
+
+
+From 15585e212aeef3a036de0220e6b9bc3105872312 Mon Sep 17 00:00:00 2001
+From: Pieter Frenssen <pieter@frenssen.be>
+Date: Thu, 10 Nov 2022 12:43:19 +0200
+Subject: [PATCH 6/9] Do not proceed with import operation if the updating of
+ existing entities is disabled.
+
+---
+ src/Importer.php | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/src/Importer.php b/src/Importer.php
+index c9d3734..5cf8fba 100644
+--- a/src/Importer.php
++++ b/src/Importer.php
+@@ -254,7 +254,7 @@ class Importer implements ImporterInterface {
+             $entity = $this->contentEntityNormalizer->denormalize(Yaml::decode($contents), $update_existing);
+           }
+
+-          if (!$entity->isNew()) {
++          if (!$entity->isNew() && !$update_existing) {
+             continue;
+           }
+
+--
+GitLab
+
+
+From 8cc356967b871ff47955c40dbdd33533fa08aac4 Mon Sep 17 00:00:00 2001
+From: Pieter Frenssen <pieter@frenssen.be>
+Date: Sun, 13 Nov 2022 13:58:45 +0200
+Subject: [PATCH 7/9] Test whether we can control if existing menu links are
+ updated.
+
+---
+ .../Kernel/MenuLinkContentNormalizerTest.php  | 107 ++++++++++++++----
+ 1 file changed, 83 insertions(+), 24 deletions(-)
+
+diff --git a/tests/src/Kernel/MenuLinkContentNormalizerTest.php b/tests/src/Kernel/MenuLinkContentNormalizerTest.php
+index b44f269..d802e99 100644
+--- a/tests/src/Kernel/MenuLinkContentNormalizerTest.php
++++ b/tests/src/Kernel/MenuLinkContentNormalizerTest.php
+@@ -39,6 +39,20 @@ class MenuLinkContentNormalizerTest extends KernelTestBase {
+    */
+   protected $exporter;
+
++  /**
++   * A node to reference in menu links.
++   *
++   * @var \Drupal\node\NodeInterface
++   */
++  protected $referencedNode;
++
++  /**
++   * A test menu link.
++   *
++   * @var \Drupal\menu_link_content\MenuLinkContentInterface
++   */
++  protected $link;
++
+   /**
+    * {@inheritdoc}
+    */
+@@ -56,31 +70,30 @@ class MenuLinkContentNormalizerTest extends KernelTestBase {
+       'type' => 'page',
+       'name' => 'page',
+     ])->save();
+-  }
+-
+-  /**
+-   * Tests menu_link_content entities.
+-   */
+-  public function testMenuLinks() {
+
+-    /** @var \Drupal\node\NodeInterface $referenced_node */
+-    $referenced_node = Node::create([
++    // Create a node to reference in menu links.
++    $this->referencedNode = Node::create([
+       'type' => 'page',
+       'title' => 'Referenced node',
+     ]);
+-    $referenced_node->save();
++    $this->referencedNode->save();
+
+-    /** @var \Drupal\menu_link_content\MenuLinkContentInterface $link */
+-    $link = MenuLinkContent::create([
++    // Create a test menu link that references the test node.
++    $this->link = MenuLinkContent::create([
+       'title' => 'Parent menu link',
+-      'link' => 'entity:node/' . $referenced_node->id(),
++      'link' => 'entity:node/' . $this->referencedNode->id(),
+     ]);
+-    $link->save();
++    $this->link->save();
++  }
+
++  /**
++   * Tests menu_link_content entities.
++   */
++  public function testMenuLinks() {
+     /** @var \Drupal\menu_link_content\MenuLinkContentInterface $child_link */
+     $child_link = MenuLinkContent::create([
+       'title' => 'Child menu link',
+-      'parent' => 'menu_link_content:' . $link->uuid(),
++      'parent' => 'menu_link_content:' . $this->link->uuid(),
+       'link' => [
+         'uri' => 'https://www.example.org',
+         'options' => [
+@@ -95,17 +108,17 @@ class MenuLinkContentNormalizerTest extends KernelTestBase {
+     /** @var \Drupal\default_content\Normalizer\ContentEntityNormalizerInterface $normalizer */
+     $normalizer = \Drupal::service('default_content.content_entity_normalizer');
+
+-    $normalized = $normalizer->normalize($link);
++    $normalized = $normalizer->normalize($this->link);
+
+     $expected = [
+       '_meta' => [
+         'version' => '1.0',
+         'entity_type' => 'menu_link_content',
+-        'uuid' => $link->uuid(),
++        'uuid' => $this->link->uuid(),
+         'bundle' => 'menu_link_content',
+         'default_langcode' => 'en',
+         'depends' => [
+-          $referenced_node->uuid() => 'node',
++          $this->referencedNode->uuid() => 'node',
+         ],
+       ],
+       'default' => [
+@@ -126,7 +139,7 @@ class MenuLinkContentNormalizerTest extends KernelTestBase {
+         ],
+         'link' => [
+           0 => [
+-            'target_uuid' => $referenced_node->uuid(),
++            'target_uuid' => $this->referencedNode->uuid(),
+             'title' => '',
+             'options' => [],
+           ],
+@@ -171,7 +184,7 @@ class MenuLinkContentNormalizerTest extends KernelTestBase {
+         'bundle' => 'menu_link_content',
+         'default_langcode' => 'en',
+         'depends' => [
+-          $link->uuid() => 'menu_link_content',
++          $this->link->uuid() => 'menu_link_content',
+         ],
+       ],
+       'default' => [
+@@ -236,19 +249,65 @@ class MenuLinkContentNormalizerTest extends KernelTestBase {
+     $this->assertEquals($expected_child, $normalized_child);
+
+     // Delete the link and referenced node and recreate them.
+-    $normalized_node = $normalizer->normalize($referenced_node);
++    $normalized_node = $normalizer->normalize($this->referencedNode);
+     $child_link->delete();
+-    $link->delete();
+-    $referenced_node->delete();
++    $this->link->delete();
++    $this->referencedNode->delete();
+
+     $recreated_node = $normalizer->denormalize($normalized_node);
+     $recreated_node->save();
+-    $this->assertNotEquals($referenced_node->id(), $recreated_node->id());
++    $this->assertNotEquals($this->referencedNode->id(), $recreated_node->id());
+
+     $recreated_link = $normalizer->denormalize($normalized);
+-    $recreated_link->save();
++    //$recreated_link->save();
++
++    // Since the original link has been deleted, this should be a new link.
++    $this->assertTrue($recreated_link->isNew());
+
+     $this->assertEquals('entity:node/' . $recreated_node->id(), $recreated_link->get('link')->uri);
+   }
+
++  /**
++   * Tests whether we can update existing menu links.
++   *
++   * @param bool $update_existing
++   *   Whether to update existing menu links.
++   *
++   * @dataProvider updateExistingMenuLinkProvider
++   */
++  public function testUpdatingExistingMenuLink($update_existing): void {
++    // Change the existing menu link to reference a different node.
++    $different_node = Node::create([
++      'type' => 'page',
++      'title' => 'Different node',
++    ]);
++    $different_node->save();
++
++    $this->link->set('link', 'entity:node/' . $different_node->id());
++
++    /** @var \Drupal\default_content\Normalizer\ContentEntityNormalizerInterface $normalizer */
++    $normalizer = \Drupal::service('default_content.content_entity_normalizer');
++    $normalized_link = $normalizer->normalize($this->link);
++    $recreated_link = $normalizer->denormalize($normalized_link, $update_existing);
++
++    // Regardless whether or not we are updating existing menu links, the link
++    // is not new since it already exists in the database.
++    $this->assertFalse($recreated_link->isNew());
++
++    // The node reference is only changes if we allow updating existing links.
++    $expected_reference = $update_existing ? 'entity:node/' . $different_node->id() : 'entity:node/' . $this->referencedNode->id();
++    $this->assertEquals($expected_reference, $recreated_link->get('link')->uri);
++  }
++
++  /**
++   * Provides test data for ::testUpdatingExistingMenuLink().
++   *
++   * @return array
++   *   An array of test data for testing both states of the '$update_existing'
++   *   parameter.
++   */
++  public function updateExistingMenuLinkProvider() {
++    return [[TRUE], [FALSE]];
++  }
++
+ }
+--
+GitLab
+
+
+From ec50803f54f5407ac95fec4c4073ed7cae9b8132 Mon Sep 17 00:00:00 2001
+From: Pieter Frenssen <pieter@frenssen.be>
+Date: Sun, 13 Nov 2022 15:08:15 +0200
+Subject: [PATCH 8/9] Test that we can control whether existing paragraph
+ entities are updated.
+
+---
+ .../Kernel/MenuLinkContentNormalizerTest.php  |  9 ++-
+ tests/src/Kernel/ParagraphNormalizerTest.php  | 57 +++++++++++++++++++
+ 2 files changed, 61 insertions(+), 5 deletions(-)
+
+diff --git a/tests/src/Kernel/MenuLinkContentNormalizerTest.php b/tests/src/Kernel/MenuLinkContentNormalizerTest.php
+index d802e99..e4100ec 100644
+--- a/tests/src/Kernel/MenuLinkContentNormalizerTest.php
++++ b/tests/src/Kernel/MenuLinkContentNormalizerTest.php
+@@ -259,16 +259,14 @@ class MenuLinkContentNormalizerTest extends KernelTestBase {
+     $this->assertNotEquals($this->referencedNode->id(), $recreated_node->id());
+
+     $recreated_link = $normalizer->denormalize($normalized);
+-    //$recreated_link->save();
++    $this->assertEquals('entity:node/' . $recreated_node->id(), $recreated_link->get('link')->uri);
+
+     // Since the original link has been deleted, this should be a new link.
+     $this->assertTrue($recreated_link->isNew());
+-
+-    $this->assertEquals('entity:node/' . $recreated_node->id(), $recreated_link->get('link')->uri);
+   }
+
+   /**
+-   * Tests whether we can update existing menu links.
++   * Tests that we can control whether existing menu links are updated or not.
+    *
+    * @param bool $update_existing
+    *   Whether to update existing menu links.
+@@ -294,7 +292,8 @@ class MenuLinkContentNormalizerTest extends KernelTestBase {
+     // is not new since it already exists in the database.
+     $this->assertFalse($recreated_link->isNew());
+
+-    // The node reference is only changes if we allow updating existing links.
++    // The node reference should only change if we allow updating existing menu
++    // links.
+     $expected_reference = $update_existing ? 'entity:node/' . $different_node->id() : 'entity:node/' . $this->referencedNode->id();
+     $this->assertEquals($expected_reference, $recreated_link->get('link')->uri);
+   }
+diff --git a/tests/src/Kernel/ParagraphNormalizerTest.php b/tests/src/Kernel/ParagraphNormalizerTest.php
+index 0528d94..8cc02f8 100644
+--- a/tests/src/Kernel/ParagraphNormalizerTest.php
++++ b/tests/src/Kernel/ParagraphNormalizerTest.php
+@@ -355,4 +355,61 @@ class ParagraphNormalizerTest extends KernelTestBase {
+     $this->assertArrayNotHasKey('paragraph', $by_entity_type);
+   }
+
++  /**
++   * Tests that we can control whether existing paragraphs are updated or not.
++   *
++   * @param bool $update_existing
++   *   Whether to update existing paragraphs.
++   *
++   * @dataProvider updateExistingParagraphsProvider
++   */
++  public function testUpdatingExistingParagraphs($update_existing): void {
++    // Create a pre-existing paragraph that references a node.
++    $referenced_node = Node::create([
++      'type' => 'page',
++      'title' => 'Referenced node',
++    ]);
++    $referenced_node->save();
++
++    $paragraph = Paragraph::create([
++      'type' => 'paragraph_type',
++      'field_node_reference' => $referenced_node,
++    ]);
++    $paragraph->save();
++
++    // Change the existing paragraph to reference a different node.
++    $different_node = Node::create([
++      'type' => 'page',
++      'title' => 'Different node',
++    ]);
++    $different_node->save();
++
++    $paragraph->set('field_node_reference', $different_node);
++
++    /** @var \Drupal\default_content\Normalizer\ContentEntityNormalizerInterface $normalizer */
++    $normalizer = \Drupal::service('default_content.content_entity_normalizer');
++    $normalized_paragraph = $normalizer->normalize($paragraph);
++    $recreated_paragraph = $normalizer->denormalize($normalized_paragraph, $update_existing);
++
++    // Regardless whether or not we are updating existing paragraphs, the
++    // paragraph is not new since it already exists in the database.
++    $this->assertFalse($recreated_paragraph->isNew());
++
++    // The node reference should only change if we allow to update existing]
++    // paragraphs.
++    $expected_reference = $update_existing ? $different_node->id() : $referenced_node->id();
++    $this->assertEquals($expected_reference, $recreated_paragraph->get('field_node_reference')->target_id);
++  }
++
++  /**
++   * Provides test data for ::testUpdatingExistingParagraphs().
++   *
++   * @return array
++   *   An array of test data for testing both states of the '$update_existing'
++   *   parameter.
++   */
++  public function updateExistingParagraphsProvider() {
++    return [[TRUE], [FALSE]];
++  }
++
+ }
+--
+GitLab
+
+
+From 4783523d61da8f3d0290fd466863d1bdf49de311 Mon Sep 17 00:00:00 2001
+From: Pieter Frenssen <pieter@frenssen.be>
+Date: Sun, 13 Nov 2022 15:51:27 +0200
+Subject: [PATCH 9/9] Test that we can control if existing content is updated
+ when importing content.
+
+---
+ ...efaultContentImportExistingContentTest.php | 277 ++++++++++++++++++
+ 1 file changed, 277 insertions(+)
+ create mode 100644 tests/src/Kernel/DefaultContentImportExistingContentTest.php
+
+diff --git a/tests/src/Kernel/DefaultContentImportExistingContentTest.php b/tests/src/Kernel/DefaultContentImportExistingContentTest.php
+new file mode 100644
+index 0000000..54fdaf9
+--- /dev/null
++++ b/tests/src/Kernel/DefaultContentImportExistingContentTest.php
+@@ -0,0 +1,277 @@
++<?php
++
++declare(strict_types = 1);
++
++namespace Drupal\Tests\default_content\Functional;
++
++use Drupal\file\Entity\File;
++use Drupal\file\FileInterface;
++use Drupal\KernelTests\KernelTestBase;
++use Drupal\taxonomy\Entity\Vocabulary;
++use Drupal\Tests\node\Traits\ContentTypeCreationTrait;
++use Drupal\Tests\node\Traits\NodeCreationTrait;
++use Drupal\Tests\taxonomy\Traits\TaxonomyTestTrait;
++use Drupal\Tests\user\Traits\UserCreationTrait;
++
++/**
++ * Tests that we can control whether existing content is updated on import.
++ *
++ * @coversDefaultClass \Drupal\default_content\Importer
++ * @group default_content
++ */
++class DefaultContentImportExistingContentTest extends KernelTestBase {
++
++  use ContentTypeCreationTrait;
++  use NodeCreationTrait;
++  use TaxonomyTestTrait;
++  use UserCreationTrait;
++
++  /**
++   * {@inheritdoc}
++   */
++  protected static $modules = [
++    'default_content',
++    'field',
++    'file',
++    'filter',
++    'node',
++    'system',
++    'taxonomy',
++    'text',
++    'user',
++  ];
++
++  /**
++   * {@inheritdoc}
++   */
++  protected function setUp(): void {
++    parent::setUp();
++
++    $this->installSchema('node', 'node_access');
++    $this->installEntitySchema('file');
++    $this->installEntitySchema('node');
++    $this->installEntitySchema('taxonomy_term');
++    $this->installEntitySchema('user');
++    $this->installSchema('file', 'file_usage');
++    $this->installConfig(['field', 'file', 'filter', 'node', 'system', 'taxonomy']);
++
++    // Create the root user since this is used as the default owner for imported
++    // content.
++    $this->createUser([], 'root', FALSE, ['uid' => 1]);
++
++    $this->createContentType(['type' => 'page']);
++
++    // Create pre-existing content entities. This is used to check if the
++    // 'default_content:import' command successfully ignores or updates
++    // existing content.
++    $nodes_to_create = [
++      [
++        'title' => 'Existing page',
++        'type' => 'page',
++        'body' => 'This is an existing page.',
++        'uuid' => '65c412a3-b83f-4efb-8a05-5a6ecea10ad4',
++      ],
++      [
++        'title' => 'Existing page 2',
++        'type' => 'page',
++        'body' => 'This is another existing page.',
++        'uuid' => '78c412a3-b83f-4efb-8a05-5a6ecea10aee',
++      ],
++    ];
++    foreach ($nodes_to_create as $node_to_create) {
++      $this->createNode($node_to_create);
++    }
++
++    $files_to_create = [
++      [
++        'filename' => 'test-file.txt',
++        'uri' => 'public://test-file.txt',
++        'uuid' => '806afcf6-05bf-4178-92dd-ae9445285770',
++      ],
++      [
++        'filename' => 'test-file2.txt',
++        'uri' => 'public://existing_file2.txt',
++        'uuid' => '806afcf6-05bf-4178-92dd-ae9445285771',
++      ],
++    ];
++    foreach ($files_to_create as $file_to_create) {
++      $this->createFile($file_to_create);
++    }
++
++    $tags_vocabulary = Vocabulary::create(['vid' => 'tags', 'name' => 'Tags']);
++    $tags_vocabulary->save();
++
++    // Create a pre-existing taxonomy term.
++    $taxonomy_term_to_create = [
++      'name' => 'A tag',
++      'vid' => $tags_vocabulary->id(),
++      'description' => '',
++      'uuid' => '550f86ad-aa11-4047-953f-636d42889f85',
++    ];
++    $this->createTerm($tags_vocabulary, $taxonomy_term_to_create);
++  }
++
++  /**
++   * Tests that existing content is only updated if $update_existing is TRUE.
++   *
++   * @covers ::importContent
++   * @dataProvider importingExistingContentDataProvider
++   */
++  public function testImportingExistingContent(bool $update_existing): void {
++    $this->container->get('default_content.importer')->importContent('default_content_test_yaml', $update_existing);
++
++    $expected_values = $update_existing ? $this->getUpdatedFieldValues() : $this->getOriginalFieldValues();
++    $this->assertFieldValues($expected_values);
++  }
++
++  /**
++   * Data provider for ::testImportingExistingContent().
++   *
++   * @return array
++   *   An array of test data for testing both states of the $update_existing
++   *   parameter.
++   */
++  public function importingExistingContentDataProvider(): array {
++    return [[TRUE], [FALSE]];
++  }
++
++  /**
++   * Asserts that a list of entities have expected field values.
++   *
++   * @param array $expected
++   *   An associative array where the keys are entity type IDs and values are
++   *   associative arrays keyed by entity UUIDs and having the expected labels
++   *   as values.
++   */
++  protected function assertFieldValues(array $expected): void {
++    $entity_type_manager = \Drupal::entityTypeManager();
++    /** @var \Drupal\Core\Entity\EntityRepositoryInterface $repository */
++    $repository = \Drupal::service('entity.repository');
++    foreach ($expected as $entity_type_id => $uuids) {
++      // Need to get fresh copies of the entities.
++      $entity_type_manager->getStorage($entity_type_id)->resetCache();
++      foreach ($uuids as $uuid => $fields) {
++        $entity = $repository->loadEntityByUuid($entity_type_id, $uuid);
++        foreach ($fields as $field_name => $expected_field_value) {
++          $this->assertSame($expected_field_value, $entity->get($field_name)->value, "Entity $entity_type_id:$uuid has the expected value for field $field_name.");
++        }
++      }
++    }
++  }
++
++  /**
++   * Returns the original field values of entities to be imported.
++   *
++   * This returns a curated list of test field values of default content in the
++   * `default_content_test_yaml` module.
++   *
++   * @return string[][][]
++   *   An associative array where the keys are entity type IDs and values are
++   *   associative arrays keyed by entity UUIDs. The values are associative
++   *   arrays keyed by field names and having the original field values as
++   *   values.
++   */
++  protected function getOriginalFieldValues(): array {
++    return [
++      'file' => [
++        '806afcf6-05bf-4178-92dd-ae9445285770' => [
++          'filename' => 'test-file.txt',
++          'uri' => 'public://test-file.txt',
++        ],
++        '806afcf6-05bf-4178-92dd-ae9445285771' => [
++          'filename' => 'test-file2.txt',
++          'uri' => 'public://existing_file2.txt',
++        ],
++      ],
++      'node' => [
++        '65c412a3-b83f-4efb-8a05-5a6ecea10ad4' => [
++          'title' => 'Existing page',
++          'body' => 'This is an existing page.',
++        ],
++        '78c412a3-b83f-4efb-8a05-5a6ecea10aee' => [
++          'title' => 'Existing page 2',
++          'body' => 'This is another existing page.',
++        ],
++      ],
++      'taxonomy_term' => [
++        '550f86ad-aa11-4047-953f-636d42889f85' => [
++          'name' => 'A tag',
++          'description' => NULL,
++        ],
++      ],
++    ];
++  }
++
++  /**
++   * Returns the updated field values of entities to be imported.
++   *
++   * This returns a curated list of test field values of default content in the
++   * `default_content_test_yaml_updated` module.
++   *
++   * @return string[][][]
++   *   Same as ::getOriginalFieldValues() but with updated field values.
++   */
++  protected function getUpdatedFieldValues(): array {
++    return [
++      'file' => [
++        '806afcf6-05bf-4178-92dd-ae9445285770' => [
++          'filename' => 'test-file.txt',
++          // Since a file already exists at that location, the updated file has
++          // automatically been suffixed with '_0'.
++          'uri' => 'public://test-file_0.txt',
++        ],
++        '806afcf6-05bf-4178-92dd-ae9445285771' => [
++          'filename' => 'test-file1.txt',
++          'uri' => 'public://example/test-file1.txt',
++        ],
++      ],
++      'node' => [
++        '65c412a3-b83f-4efb-8a05-5a6ecea10ad4' => [
++          'title' => 'Imported node',
++          'body' => 'Crikey it works!',
++        ],
++        '78c412a3-b83f-4efb-8a05-5a6ecea10aee' => [
++          'title' => 'Imported node with owned by user that does not exist',
++          'body' => 'Crikey it works!',
++        ],
++      ],
++      'taxonomy_term' => [
++        '550f86ad-aa11-4047-953f-636d42889f85' => [
++          'name' => 'A tag',
++          'description' => NULL,
++        ],
++      ],
++    ];
++  }
++
++  /**
++   * Creates and saves a test file.
++   *
++   * @param array $values
++   *   An array of values to set, keyed by property name.
++   *
++   * @return \Drupal\file\FileInterface
++   *   A file entity.
++   */
++  protected function createFile(array $values): FileInterface {
++    // Add defaults for missing properties.
++    $values += [
++      'uid' => 1,
++      'filename' => 'default_content_test_file.txt',
++      'uri' => 'public://default_content_test_file.txt',
++      'filemime' => 'text/plain',
++      'created' => 1,
++      'changed' => 1,
++    ];
++
++    $file = File::create($values);
++    $file->setPermanent();
++
++    file_put_contents($file->getFileUri(), 'hello world');
++
++    $file->save();
++
++    return $file;
++  }
++
++}
+--
+GitLab

--- a/web/modules/custom/default_content_config/default_content_config.info.yml
+++ b/web/modules/custom/default_content_config/default_content_config.info.yml
@@ -1,0 +1,7 @@
+name: 'Default Content Config'
+type: module
+description: 'Provides the configuration that creates default content entities.'
+package: Custom
+core_version_requirement: ^10 || ^11
+dependencies:
+  - default_content:default_content


### PR DESCRIPTION
See the new CONTRIBUTING.md file.

Please create a node and use the documentation to learn how to export the content.

After you export the content, run `lando si` and your content should be created again.