### PR TITLE
Convert text into plain or html for migration

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -35,7 +35,7 @@
         "drupal/twig_tweak": "^3.3",
         "drupal/uswds_templates": "^3.0@dev",
         "drush/drush": "^12.5",
-        "league/commonmark": "^1.0",
+        "league/commonmark": "^2.5",
         "mattsqd/drupal-env": "dev-main",
         "mattsqd/drupal-env-lando": "dev-main"
     },

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "286e99c697432ec5c9f9e95bc4e97c27",
+    "content-hash": "6428dc1f0fc8c85c9a70c64d8f7be3c6",
     "packages": [
         {
             "name": "asm89/stack-cors",
@@ -3127,42 +3127,54 @@
         },
         {
             "name": "league/commonmark",
-            "version": "1.6.7",
+            "version": "2.5.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/thephpleague/commonmark.git",
-                "reference": "2b8185c13bc9578367a5bf901881d1c1b5bbd09b"
+                "reference": "b650144166dfa7703e62a22e493b853b58d874b0"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/thephpleague/commonmark/zipball/2b8185c13bc9578367a5bf901881d1c1b5bbd09b",
-                "reference": "2b8185c13bc9578367a5bf901881d1c1b5bbd09b",
+                "url": "https://api.github.com/repos/thephpleague/commonmark/zipball/b650144166dfa7703e62a22e493b853b58d874b0",
+                "reference": "b650144166dfa7703e62a22e493b853b58d874b0",
                 "shasum": ""
             },
             "require": {
                 "ext-mbstring": "*",
-                "php": "^7.1 || ^8.0"
-            },
-            "conflict": {
-                "scrutinizer/ocular": "1.7.*"
+                "league/config": "^1.1.1",
+                "php": "^7.4 || ^8.0",
+                "psr/event-dispatcher": "^1.0",
+                "symfony/deprecation-contracts": "^2.1 || ^3.0",
+                "symfony/polyfill-php80": "^1.16"
             },
             "require-dev": {
-                "cebe/markdown": "~1.0",
-                "commonmark/commonmark.js": "0.29.2",
-                "erusev/parsedown": "~1.0",
+                "cebe/markdown": "^1.0",
+                "commonmark/cmark": "0.31.1",
+                "commonmark/commonmark.js": "0.31.1",
+                "composer/package-versions-deprecated": "^1.8",
+                "embed/embed": "^4.4",
+                "erusev/parsedown": "^1.0",
                 "ext-json": "*",
                 "github/gfm": "0.29.0",
-                "michelf/php-markdown": "~1.4",
-                "mikehaertl/php-shellcommand": "^1.4",
-                "phpstan/phpstan": "^0.12.90",
-                "phpunit/phpunit": "^7.5 || ^8.5 || ^9.2",
-                "scrutinizer/ocular": "^1.5",
-                "symfony/finder": "^4.2"
+                "michelf/php-markdown": "^1.4 || ^2.0",
+                "nyholm/psr7": "^1.5",
+                "phpstan/phpstan": "^1.8.2",
+                "phpunit/phpunit": "^9.5.21 || ^10.5.9 || ^11.0.0",
+                "scrutinizer/ocular": "^1.8.1",
+                "symfony/finder": "^5.3 | ^6.0 || ^7.0",
+                "symfony/yaml": "^2.3 | ^3.0 | ^4.0 | ^5.0 | ^6.0 || ^7.0",
+                "unleashedtech/php-coding-standard": "^3.1.1",
+                "vimeo/psalm": "^4.24.0 || ^5.0.0"
             },
-            "bin": [
-                "bin/commonmark"
-            ],
+            "suggest": {
+                "symfony/yaml": "v2.3+ required if using the Front Matter extension"
+            },
             "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-main": "2.6-dev"
+                }
+            },
             "autoload": {
                 "psr-4": {
                     "League\\CommonMark\\": "src"
@@ -3180,7 +3192,7 @@
                     "role": "Lead Developer"
                 }
             ],
-            "description": "Highly-extensible PHP Markdown parser which fully supports the CommonMark spec and Github-Flavored Markdown (GFM)",
+            "description": "Highly-extensible PHP Markdown parser which fully supports the CommonMark spec and GitHub-Flavored Markdown (GFM)",
             "homepage": "https://commonmark.thephpleague.com",
             "keywords": [
                 "commonmark",
@@ -3194,6 +3206,7 @@
             ],
             "support": {
                 "docs": "https://commonmark.thephpleague.com/",
+                "forum": "https://github.com/thephpleague/commonmark/discussions",
                 "issues": "https://github.com/thephpleague/commonmark/issues",
                 "rss": "https://github.com/thephpleague/commonmark/releases.atom",
                 "source": "https://github.com/thephpleague/commonmark"
@@ -3216,7 +3229,89 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2022-01-13T17:18:13+00:00"
+            "time": "2024-08-16T11:46:16+00:00"
+        },
+        {
+            "name": "league/config",
+            "version": "v1.2.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/thephpleague/config.git",
+                "reference": "754b3604fb2984c71f4af4a9cbe7b57f346ec1f3"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/thephpleague/config/zipball/754b3604fb2984c71f4af4a9cbe7b57f346ec1f3",
+                "reference": "754b3604fb2984c71f4af4a9cbe7b57f346ec1f3",
+                "shasum": ""
+            },
+            "require": {
+                "dflydev/dot-access-data": "^3.0.1",
+                "nette/schema": "^1.2",
+                "php": "^7.4 || ^8.0"
+            },
+            "require-dev": {
+                "phpstan/phpstan": "^1.8.2",
+                "phpunit/phpunit": "^9.5.5",
+                "scrutinizer/ocular": "^1.8.1",
+                "unleashedtech/php-coding-standard": "^3.1",
+                "vimeo/psalm": "^4.7.3"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-main": "1.2-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "League\\Config\\": "src"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Colin O'Dell",
+                    "email": "colinodell@gmail.com",
+                    "homepage": "https://www.colinodell.com",
+                    "role": "Lead Developer"
+                }
+            ],
+            "description": "Define configuration arrays with strict schemas and access values with dot notation",
+            "homepage": "https://config.thephpleague.com",
+            "keywords": [
+                "array",
+                "config",
+                "configuration",
+                "dot",
+                "dot-access",
+                "nested",
+                "schema"
+            ],
+            "support": {
+                "docs": "https://config.thephpleague.com/",
+                "issues": "https://github.com/thephpleague/config/issues",
+                "rss": "https://github.com/thephpleague/config/releases.atom",
+                "source": "https://github.com/thephpleague/config"
+            },
+            "funding": [
+                {
+                    "url": "https://www.colinodell.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://www.paypal.me/colinpodell/10.00",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/colinodell",
+                    "type": "github"
+                }
+            ],
+            "time": "2022-12-11T20:36:23+00:00"
         },
         {
             "name": "league/container",
@@ -3697,6 +3792,154 @@
                 "source": "https://github.com/mck89/peast/tree/v1.16.3"
             },
             "time": "2024-07-23T14:00:32+00:00"
+        },
+        {
+            "name": "nette/schema",
+            "version": "v1.3.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/nette/schema.git",
+                "reference": "a6d3a6d1f545f01ef38e60f375d1cf1f4de98188"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/nette/schema/zipball/a6d3a6d1f545f01ef38e60f375d1cf1f4de98188",
+                "reference": "a6d3a6d1f545f01ef38e60f375d1cf1f4de98188",
+                "shasum": ""
+            },
+            "require": {
+                "nette/utils": "^4.0",
+                "php": "8.1 - 8.3"
+            },
+            "require-dev": {
+                "nette/tester": "^2.4",
+                "phpstan/phpstan-nette": "^1.0",
+                "tracy/tracy": "^2.8"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.3-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause",
+                "GPL-2.0-only",
+                "GPL-3.0-only"
+            ],
+            "authors": [
+                {
+                    "name": "David Grudl",
+                    "homepage": "https://davidgrudl.com"
+                },
+                {
+                    "name": "Nette Community",
+                    "homepage": "https://nette.org/contributors"
+                }
+            ],
+            "description": "📐 Nette Schema: validating data structures against a given Schema.",
+            "homepage": "https://nette.org",
+            "keywords": [
+                "config",
+                "nette"
+            ],
+            "support": {
+                "issues": "https://github.com/nette/schema/issues",
+                "source": "https://github.com/nette/schema/tree/v1.3.0"
+            },
+            "time": "2023-12-11T11:54:22+00:00"
+        },
+        {
+            "name": "nette/utils",
+            "version": "v4.0.5",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/nette/utils.git",
+                "reference": "736c567e257dbe0fcf6ce81b4d6dbe05c6899f96"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/nette/utils/zipball/736c567e257dbe0fcf6ce81b4d6dbe05c6899f96",
+                "reference": "736c567e257dbe0fcf6ce81b4d6dbe05c6899f96",
+                "shasum": ""
+            },
+            "require": {
+                "php": "8.0 - 8.4"
+            },
+            "conflict": {
+                "nette/finder": "<3",
+                "nette/schema": "<1.2.2"
+            },
+            "require-dev": {
+                "jetbrains/phpstorm-attributes": "dev-master",
+                "nette/tester": "^2.5",
+                "phpstan/phpstan": "^1.0",
+                "tracy/tracy": "^2.9"
+            },
+            "suggest": {
+                "ext-gd": "to use Image",
+                "ext-iconv": "to use Strings::webalize(), toAscii(), chr() and reverse()",
+                "ext-intl": "to use Strings::webalize(), toAscii(), normalize() and compare()",
+                "ext-json": "to use Nette\\Utils\\Json",
+                "ext-mbstring": "to use Strings::lower() etc...",
+                "ext-tokenizer": "to use Nette\\Utils\\Reflection::getUseStatements()"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "4.0-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause",
+                "GPL-2.0-only",
+                "GPL-3.0-only"
+            ],
+            "authors": [
+                {
+                    "name": "David Grudl",
+                    "homepage": "https://davidgrudl.com"
+                },
+                {
+                    "name": "Nette Community",
+                    "homepage": "https://nette.org/contributors"
+                }
+            ],
+            "description": "🛠  Nette Utils: lightweight utilities for string & array manipulation, image handling, safe JSON encoding/decoding, validation, slug or strong password generating etc.",
+            "homepage": "https://nette.org",
+            "keywords": [
+                "array",
+                "core",
+                "datetime",
+                "images",
+                "json",
+                "nette",
+                "paginator",
+                "password",
+                "slugify",
+                "string",
+                "unicode",
+                "utf-8",
+                "utility",
+                "validation"
+            ],
+            "support": {
+                "issues": "https://github.com/nette/utils/issues",
+                "source": "https://github.com/nette/utils/tree/v4.0.5"
+            },
+            "time": "2024-08-07T15:39:19+00:00"
         },
         {
             "name": "nikic/php-parser",

--- a/composer.log
+++ b/composer.log
@@ -15,3 +15,4 @@ ae2759e9c45acbf0d8378d04e842d0a8|Matt Poole|develop|Tue Jul  2 13:45:43 EDT 2024
 3b53a72eee437f256a7c519f1cbbacdb|Matt Poole|feature/update-deps|Thu Sep 26 10:11:13 EDT 2024|./composer.sh require mattsqd/drupal-env-lando:dev-main
 51b1db8a23eabb3f084cd6f4caac2351|Matt Poole|feature/update-deps|Thu Sep 26 10:14:06 EDT 2024|./composer.sh update
 988761caf540bfc9c7d6bdb1d884208d|Matt Poole|feature/default-content|Fri Sep 27 13:52:06 EDT 2024|./composer.sh require drupal/default_content:^2.0@alpha
+3c60f8865d24ef2346cc2379cf42e591|Matt Poole|feature/1942-convert-callback|Fri Oct  4 10:49:29 EDT 2024|./composer.sh require league/commonmark

--- a/config/sync/core.extension.yml
+++ b/config/sync/core.extension.yml
@@ -11,6 +11,7 @@ module:
   comment: 0
   content_moderation: 0
   content_moderation_notifications: 0
+  convert_text: 0
   datetime: 0
   dblog: 0
   default_content: 0

--- a/web/modules/custom/convert_text/convert_text.info.yml
+++ b/web/modules/custom/convert_text/convert_text.info.yml
@@ -1,0 +1,5 @@
+name: 'Convert Text'
+type: module
+description: 'Converts text to and from various formats.'
+package: Custom
+core_version_requirement: ^10 || ^11

--- a/web/modules/custom/convert_text/convert_text.module
+++ b/web/modules/custom/convert_text/convert_text.module
@@ -1,0 +1,6 @@
+<?php
+
+/**
+ * @file
+ * Primary module hooks for Convert Text module.
+ */

--- a/web/modules/custom/convert_text/convert_text.routing.yml
+++ b/web/modules/custom/convert_text/convert_text.routing.yml
@@ -1,0 +1,9 @@
+convert_text.convert_text:
+  path: '/admin/convert-text'
+  defaults:
+    _title: 'Convert Text'
+    _form: 'Drupal\convert_text\Form\ConvertTextForm'
+  requirements:
+    _permission: 'administer content'
+  options:
+    _admin_route: TRUE

--- a/web/modules/custom/convert_text/src/ConvertText.php
+++ b/web/modules/custom/convert_text/src/ConvertText.php
@@ -1,0 +1,71 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Drupal\convert_text;
+
+use League\CommonMark\CommonMarkConverter;
+
+/**
+ * Provides methods to convert migrated text for fields.
+ */
+class ConvertText {
+
+  /**
+   * Converts text for the given $field_type.
+   *
+   * @var string $source_text
+   *   The original source value.
+   * @var string $field_type
+   *   Either plain or html.
+   *
+   * @return string
+   *   The converted text.
+   */
+  static protected function convertText(string $source_text, string $field_type): string {
+    // Start by removing space before and after.
+    $source_text = trim($source_text);
+    // Remove extra spaces before new lines.
+    $source_text = preg_replace('/\n\s+n/', "\n", $source_text);
+
+    switch ($field_type) {
+      case 'plain_text':
+        return html_entity_decode($source_text,ENT_QUOTES | ENT_SUBSTITUTE | ENT_HTML401 , 'UTF-8');
+
+      case 'html':
+        $converter = new CommonMarkConverter();
+        return $converter->convert($source_text)->getContent();
+
+      default:
+        throw new \Exception("Invalid \$field_type of $field_type given");
+
+    }
+  }
+
+  /**
+   * Gets text ready to be stored in plain text fields.
+   *
+   * @var string $source_text
+   *   The original source value.
+   *
+   * @return string
+   *    The converted text.
+   */
+  static public function plainText(string $source_text): string {
+    return self::convertText($source_text, 'plain_text');
+  }
+
+  /**
+   * Gets text ready to be stored in html text fields.
+   *
+   * @var string $source_text
+   *    The original source value.
+   *
+   * @return string
+   *    The converted text.
+   */
+  static public function htmlText(string $source_text): string {
+    return self::convertText($source_text, 'html');
+  }
+
+}

--- a/web/modules/custom/convert_text/src/Form/ConvertTextForm.php
+++ b/web/modules/custom/convert_text/src/Form/ConvertTextForm.php
@@ -1,0 +1,95 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Drupal\convert_text\Form;
+
+use Drupal\convert_text\ConvertText;
+use Drupal\Core\Form\FormBase;
+use Drupal\Core\Form\FormStateInterface;
+
+/**
+ * Provides a Convert Text form.
+ */
+final class ConvertTextForm extends FormBase {
+
+  /**
+   * {@inheritdoc}
+   */
+  public function getFormId(): string {
+    return 'convert_text_convert_text';
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function buildForm(array $form, FormStateInterface $form_state): array {
+
+    if ($converted_text = $form_state->getValue('converted_text')) {
+      $form['converted_text'] = [
+        '#type' => 'textarea',
+        '#title' => $this->t('Converted Text'),
+        '#default_value' => $converted_text,
+        '#disabled' => TRUE,
+      ];
+    }
+
+    $form['source_text'] = [
+      '#type' => 'textarea',
+      '#title' => $this->t('Source Text'),
+      '#required' => TRUE,
+    ];
+    $form['dest'] = [
+      '#type' => 'radios',
+      '#title' => $this->t('Destination'),
+      '#options' => [
+        'plain_text' => $this->t('Fields like title. This will decode the HTML entities like &amp;#8221 into ” (right double quotation mark).'),
+        'html' => $this->t('Fields like body that summary or body that will contain HTML and Markdown'),
+      ],
+      '#required' => TRUE,
+    ];
+    $form['actions'] = [
+      '#type' => 'actions',
+      'submit' => [
+        '#type' => 'submit',
+        '#value' => $this->t('Convert'),
+      ],
+      'reset' => [
+        '#type' => 'submit',
+        '#value' => $this->t('Reset'),
+      ]
+    ];
+
+    return $form;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function submitForm(array &$form, FormStateInterface $form_state): void {
+    if ((string) $form_state->getValue('op') === 'Reset') {
+      return;
+    }
+    $source_text = $form_state->getValue('source_text');
+
+    switch ($form_state->getValue('dest')) {
+      case 'plain_text':
+        $decoded_entities = ConvertText::plainText($source_text);
+        $form_state->setValue('converted_text', $decoded_entities);
+        $this->messenger()->addStatus($this->t('Copy the converted text field into a plain text field.'));
+        break;
+
+      case 'html':
+        $html = ConvertText::htmlText($source_text);
+        $form_state->setValue('converted_text', $html);
+        $this->messenger()->addStatus($this->t('Copy the converted text field into an HTML field. If using a WYSIWYG, click "source" first.'));
+        break;
+
+    }
+
+    // Allows the form state values to persist after submission so form is pre-
+    // filled with same options.
+    $form_state->setRebuild();
+  }
+
+}


### PR DESCRIPTION
I used this text as my test text:
```
RAQ: |”&#8221;|
NBSP: | &nbsp;&nbsp;sdfsdf|
AMP: |&&amp;     |
QUOTE: |"&quot;|
SINGLEQ: |'&#039;|

LT:  |<&lt;|
GT: |>&gt;|
<span id="mooo">"some" &quot;stuff&quot;[A link](https://www.google.com)</span>
<span id='single-quotes'>Do single quotes get preserved&#039;?</span>
```

The new admin page can be found [here](http://digitalgov.lndo.site/admin/convert-text)

This is pretty confusing, but the idea is, that if it's destined for HTML and you take the converted text and paste it into the 'Source' of an HTML Drupal field, when you click off 'Source':
* The markdown should be html (I added a markdown link)
* All the crazy looking entities like &quot; and &#8221; should look like a " and ” instead.
* Non breaking spaces (&nbsp;) should cause ACTUAL space in the display. Notice how the spaces before sdfsdf show up but there is no space after the &&amp;?

A big note for this is that Drupal handles some characters strangely when you're looking at the 'source'. For example, &quot; will always be " and it turns ' into " for HTML attributes. That's all fine, as long as what it looks like when you're off 'source' looks right.

For plain text, if you paste these into a non-WYSIWYG field:
* The markdown should not be html (there should be no link)
* The crazy characters should be turned into their equavalent characters without needing to look at the non-source value.