### PR TITLE
DIGITAL-107: Add missing 'External URL' field to short post

### DIFF
--- a/config/sync/core.entity_form_display.node.short_post.default.yml
+++ b/config/sync/core.entity_form_display.node.short_post.default.yml
@@ -4,15 +4,18 @@ status: true
 dependencies:
   config:
     - field.field.node.short_post.field_deck
+    - field.field.node.short_post.field_external_url
     - field.field.node.short_post.field_short_post_type
     - field.field.node.short_post.field_slug
     - field.field.node.short_post.field_source
     - field.field.node.short_post.field_summary
     - field.field.node.short_post.field_topics
     - node.type.short_post
+    - workflows.workflow.editorial
   module:
     - content_moderation
     - inline_entity_form
+    - link
     - text
 id: node.short_post.default
 targetEntityType: node
@@ -21,7 +24,7 @@ mode: default
 content:
   created:
     type: datetime_timestamp
-    weight: 7
+    weight: 8
     region: content
     settings: {  }
     third_party_settings: {  }
@@ -33,9 +36,17 @@ content:
       size: 60
       placeholder: ''
     third_party_settings: {  }
+  field_external_url:
+    type: link_default
+    weight: 4
+    region: content
+    settings:
+      placeholder_url: ''
+      placeholder_title: ''
+    third_party_settings: {  }
   field_short_post_type:
     type: options_select
-    weight: 4
+    weight: 5
     region: content
     settings: {  }
     third_party_settings: {  }
@@ -67,7 +78,7 @@ content:
     third_party_settings: {  }
   field_topics:
     type: inline_entity_form_complex
-    weight: 5
+    weight: 6
     region: content
     settings:
       form_mode: default
@@ -85,27 +96,27 @@ content:
     third_party_settings: {  }
   moderation_state:
     type: moderation_state_default
-    weight: 10
+    weight: 11
     region: content
     settings: {  }
     third_party_settings: {  }
   promote:
     type: boolean_checkbox
-    weight: 8
+    weight: 9
     region: content
     settings:
       display_label: true
     third_party_settings: {  }
   status:
     type: boolean_checkbox
-    weight: 11
+    weight: 12
     region: content
     settings:
       display_label: true
     third_party_settings: {  }
   sticky:
     type: boolean_checkbox
-    weight: 9
+    weight: 10
     region: content
     settings:
       display_label: true
@@ -120,7 +131,7 @@ content:
     third_party_settings: {  }
   uid:
     type: inline_entity_form_complex
-    weight: 6
+    weight: 7
     region: content
     settings:
       form_mode: default
@@ -137,7 +148,7 @@ content:
       removed_reference: optional
     third_party_settings: {  }
   url_redirects:
-    weight: 50
+    weight: 13
     region: content
     settings: {  }
     third_party_settings: {  }

--- a/config/sync/core.entity_view_display.node.short_post.default.yml
+++ b/config/sync/core.entity_view_display.node.short_post.default.yml
@@ -4,6 +4,7 @@ status: true
 dependencies:
   config:
     - field.field.node.short_post.field_deck
+    - field.field.node.short_post.field_external_url
     - field.field.node.short_post.field_short_post_type
     - field.field.node.short_post.field_slug
     - field.field.node.short_post.field_source
@@ -11,62 +12,19 @@ dependencies:
     - field.field.node.short_post.field_topics
     - node.type.short_post
   module:
-    - options
-    - text
     - user
 id: node.short_post.default
 targetEntityType: node
 bundle: short_post
 mode: default
-content:
-  field_deck:
-    type: text_default
-    label: above
-    settings: {  }
-    third_party_settings: {  }
-    weight: 108
-    region: content
-  field_short_post_type:
-    type: list_default
-    label: above
-    settings: {  }
-    third_party_settings: {  }
-    weight: 127
-    region: content
-  field_slug:
-    type: string
-    label: above
-    settings:
-      link_to_entity: false
-    third_party_settings: {  }
-    weight: 106
-    region: content
-  field_source:
-    type: entity_reference_label
-    label: above
-    settings:
-      link: true
-    third_party_settings: {  }
-    weight: 126
-    region: content
-  field_summary:
-    type: text_default
-    label: above
-    settings: {  }
-    third_party_settings: {  }
-    weight: 104
-    region: content
-  field_topics:
-    type: entity_reference_label
-    label: above
-    settings:
-      link: true
-    third_party_settings: {  }
-    weight: 125
-    region: content
-  links:
-    settings: {  }
-    third_party_settings: {  }
-    weight: 100
-    region: content
-hidden: {  }
+content: {  }
+hidden:
+  content_moderation_control: true
+  field_deck: true
+  field_external_url: true
+  field_short_post_type: true
+  field_slug: true
+  field_source: true
+  field_summary: true
+  field_topics: true
+  links: true

--- a/config/sync/core.entity_view_display.node.short_post.teaser.yml
+++ b/config/sync/core.entity_view_display.node.short_post.teaser.yml
@@ -5,6 +5,7 @@ dependencies:
   config:
     - core.entity_view_mode.node.teaser
     - field.field.node.short_post.field_deck
+    - field.field.node.short_post.field_external_url
     - field.field.node.short_post.field_short_post_type
     - field.field.node.short_post.field_slug
     - field.field.node.short_post.field_source
@@ -12,21 +13,80 @@ dependencies:
     - field.field.node.short_post.field_topics
     - node.type.short_post
   module:
+    - link
+    - options
+    - text
     - user
 id: node.short_post.teaser
 targetEntityType: node
 bundle: short_post
 mode: teaser
 content:
+  content_moderation_control:
+    settings: {  }
+    third_party_settings: {  }
+    weight: 6
+    region: content
+  field_deck:
+    type: text_default
+    label: above
+    settings: {  }
+    third_party_settings: {  }
+    weight: 0
+    region: content
+  field_external_url:
+    type: link
+    label: above
+    settings:
+      trim_length: 80
+      url_only: false
+      url_plain: false
+      rel: ''
+      target: ''
+    third_party_settings: {  }
+    weight: 1
+    region: content
+  field_short_post_type:
+    type: list_default
+    label: above
+    settings: {  }
+    third_party_settings: {  }
+    weight: 2
+    region: content
+  field_slug:
+    type: string
+    label: above
+    settings:
+      link_to_entity: false
+    third_party_settings: {  }
+    weight: 3
+    region: content
+  field_source:
+    type: entity_reference_label
+    label: above
+    settings:
+      link: true
+    third_party_settings: {  }
+    weight: 4
+    region: content
+  field_summary:
+    type: text_default
+    label: above
+    settings: {  }
+    third_party_settings: {  }
+    weight: 5
+    region: content
+  field_topics:
+    type: entity_reference_label
+    label: above
+    settings:
+      link: true
+    third_party_settings: {  }
+    weight: 7
+    region: content
   links:
     settings: {  }
     third_party_settings: {  }
-    weight: 100
+    weight: 8
     region: content
-hidden:
-  field_deck: true
-  field_short_post_type: true
-  field_slug: true
-  field_source: true
-  field_summary: true
-  field_topics: true
+hidden: {  }

--- a/config/sync/field.field.node.short_post.field_external_url.yml
+++ b/config/sync/field.field.node.short_post.field_external_url.yml
@@ -1,0 +1,23 @@
+uuid: 0f4c1b1d-01ba-452e-a83f-75968442ed74
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.node.field_external_url
+    - node.type.short_post
+  module:
+    - link
+id: node.short_post.field_external_url
+field_name: field_external_url
+entity_type: node
+bundle: short_post
+label: 'External URL'
+description: ''
+required: true
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings:
+  title: 0
+  link_type: 16
+field_type: link

--- a/config/sync/field.storage.node.field_external_url.yml
+++ b/config/sync/field.storage.node.field_external_url.yml
@@ -1,0 +1,19 @@
+uuid: cab9b605-c196-4f27-bf82-15bc5ad60f33
+langcode: en
+status: true
+dependencies:
+  module:
+    - link
+    - node
+id: node.field_external_url
+field_name: field_external_url
+entity_type: node
+type: link
+settings: {  }
+module: link
+locked: false
+cardinality: 1
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false

--- a/config/sync/views.view.authmap.yml
+++ b/config/sync/views.view.authmap.yml
@@ -16,104 +16,12 @@ base_table: authmap
 base_field: uid
 display:
   default:
-    display_plugin: default
     id: default
     display_title: Master
+    display_plugin: default
     position: 0
     display_options:
-      access:
-        type: perm
-        options:
-          perm: 'view authmap'
-      cache:
-        type: none
-        options: {  }
-      query:
-        type: views_query
-        options:
-          disable_sql_rewrite: false
-          distinct: false
-          replica: false
-          query_comment: ''
-          query_tags: {  }
-      exposed_form:
-        type: basic
-        options:
-          submit_button: Apply
-          reset_button: false
-          reset_button_label: Reset
-          exposed_sorts_label: 'Sort by'
-          expose_sort_order: true
-          sort_asc_label: Asc
-          sort_desc_label: Desc
-      pager:
-        type: mini
-        options:
-          items_per_page: 50
-          offset: 0
-          id: 0
-          total_pages: null
-          expose:
-            items_per_page: false
-            items_per_page_label: 'Items per page'
-            items_per_page_options: '5, 10, 25, 50'
-            items_per_page_options_all: false
-            items_per_page_options_all_label: '- All -'
-            offset: false
-            offset_label: Offset
-          tags:
-            previous: ‹‹
-            next: ››
-          pagination_heading_level: h4
-      style:
-        type: table
-        options:
-          grouping: {  }
-          row_class: ''
-          default_row_class: true
-          override: true
-          sticky: false
-          caption: ''
-          summary: ''
-          description: ''
-          columns:
-            authname: authname
-            uid: uid
-            name: name
-            delete: delete
-          info:
-            authname:
-              sortable: true
-              default_sort_order: asc
-              align: ''
-              separator: ''
-              empty_column: false
-              responsive: ''
-            uid:
-              sortable: true
-              default_sort_order: asc
-              align: ''
-              separator: ''
-              empty_column: false
-              responsive: ''
-            name:
-              sortable: true
-              default_sort_order: asc
-              align: ''
-              separator: ''
-              empty_column: false
-              responsive: ''
-            delete:
-              sortable: false
-              default_sort_order: asc
-              align: ''
-              separator: ''
-              empty_column: false
-              responsive: ''
-          default: authname
-          empty_table: false
-      row:
-        type: fields
+      title: 'External authentication links'
       fields:
         provider_field:
           id: provider_field
@@ -122,6 +30,7 @@ display:
           relationship: none
           group_type: group
           admin_label: ''
+          plugin_id: standard
           label: ''
           exclude: true
           alter:
@@ -163,7 +72,6 @@ display:
           hide_empty: false
           empty_zero: false
           hide_alter_empty: true
-          plugin_id: standard
         authname:
           id: authname
           table: authmap
@@ -171,6 +79,7 @@ display:
           relationship: none
           group_type: group
           admin_label: ''
+          plugin_id: standard
           label: 'Authentication Name'
           exclude: false
           alter:
@@ -212,7 +121,6 @@ display:
           hide_empty: false
           empty_zero: false
           hide_alter_empty: true
-          plugin_id: standard
         uid:
           id: uid
           table: authmap
@@ -220,6 +128,7 @@ display:
           relationship: none
           group_type: group
           admin_label: ''
+          plugin_id: numeric
           label: 'Drupal User ID'
           exclude: false
           alter:
@@ -269,7 +178,6 @@ display:
           format_plural_string: !!binary MQNAY291bnQ=
           prefix: ''
           suffix: ''
-          plugin_id: numeric
         name:
           id: name
           table: users_field_data
@@ -277,6 +185,9 @@ display:
           relationship: uid
           group_type: group
           admin_label: ''
+          entity_type: user
+          entity_field: name
+          plugin_id: field
           label: 'Drupal User Name'
           exclude: false
           alter:
@@ -332,9 +243,6 @@ display:
           multi_type: separator
           separator: ', '
           field_api_classes: false
-          entity_type: user
-          entity_field: name
-          plugin_id: field
         delete_link:
           id: delete_link
           table: authmap
@@ -342,6 +250,7 @@ display:
           relationship: none
           group_type: group
           admin_label: ''
+          plugin_id: authmap_link_delete
           label: delete
           exclude: false
           alter:
@@ -386,7 +295,94 @@ display:
           text: delete
           output_url_as_text: false
           absolute: false
-          plugin_id: authmap_link_delete
+      pager:
+        type: mini
+        options:
+          offset: 0
+          pagination_heading_level: h4
+          items_per_page: 50
+          total_pages: null
+          id: 0
+          tags:
+            next: ››
+            previous: ‹‹
+          expose:
+            items_per_page: false
+            items_per_page_label: 'Items per page'
+            items_per_page_options: '5, 10, 25, 50'
+            items_per_page_options_all: false
+            items_per_page_options_all_label: '- All -'
+            offset: false
+            offset_label: Offset
+      exposed_form:
+        type: basic
+        options:
+          submit_button: Apply
+          reset_button: false
+          reset_button_label: Reset
+          exposed_sorts_label: 'Sort by'
+          expose_sort_order: true
+          sort_asc_label: Asc
+          sort_desc_label: Desc
+      access:
+        type: perm
+        options:
+          perm: 'view authmap'
+      cache:
+        type: none
+        options: {  }
+      empty:
+        area_text_custom:
+          id: area_text_custom
+          table: views
+          field: area_text_custom
+          relationship: none
+          group_type: group
+          admin_label: ''
+          plugin_id: text_custom
+          empty: true
+          content: 'No links (from Authentication name to Drupal user) found.'
+          tokenize: false
+      sorts: {  }
+      arguments:
+        provider_field:
+          id: provider_field
+          table: authmap
+          field: provider_field
+          relationship: none
+          group_type: group
+          admin_label: ''
+          plugin_id: string
+          default_action: ignore
+          exception:
+            value: all
+            title_enable: false
+            title: All
+          title_enable: true
+          title: 'Links for {{ arguments.provider_field }}'
+          default_argument_type: fixed
+          default_argument_options:
+            argument: ''
+          summary_options:
+            base_path: ''
+            count: false
+            override: false
+            items_per_page: 25
+          summary:
+            sort_order: asc
+            number_of_records: 0
+            format: default_summary
+          specify_validation: false
+          validate:
+            type: none
+            fail: 'not found'
+          validate_options: {  }
+          glossary: false
+          limit: 0
+          case: none
+          path_case: none
+          transform_dash: false
+          break_phrase: false
       filters:
         authname:
           id: authname
@@ -395,6 +391,7 @@ display:
           relationship: none
           group_type: group
           admin_label: ''
+          plugin_id: string
           operator: starts
           value: ''
           group: 1
@@ -430,7 +427,6 @@ display:
             default_group: All
             default_group_multiple: {  }
             group_items: {  }
-          plugin_id: string
         uid:
           id: uid
           table: users_field_data
@@ -438,6 +434,9 @@ display:
           relationship: uid
           group_type: group
           admin_label: ''
+          entity_type: user
+          entity_field: uid
+          plugin_id: user_name
           operator: in
           value: {  }
           group: 1
@@ -473,25 +472,63 @@ display:
             default_group: All
             default_group_multiple: {  }
             group_items: {  }
-          entity_type: user
-          entity_field: uid
-          plugin_id: user_name
-      sorts: {  }
-      title: 'External authentication links'
-      header: {  }
-      footer: {  }
-      empty:
-        area_text_custom:
-          id: area_text_custom
-          table: views
-          field: area_text_custom
-          relationship: none
-          group_type: group
-          admin_label: ''
-          empty: true
-          tokenize: false
-          content: 'No links (from Authentication name to Drupal user) found.'
-          plugin_id: text_custom
+      style:
+        type: table
+        options:
+          grouping: {  }
+          row_class: ''
+          default_row_class: true
+          columns:
+            authname: authname
+            uid: uid
+            name: name
+            delete: delete
+          default: authname
+          info:
+            authname:
+              sortable: true
+              default_sort_order: asc
+              align: ''
+              separator: ''
+              empty_column: false
+              responsive: ''
+            uid:
+              sortable: true
+              default_sort_order: asc
+              align: ''
+              separator: ''
+              empty_column: false
+              responsive: ''
+            name:
+              sortable: true
+              default_sort_order: asc
+              align: ''
+              separator: ''
+              empty_column: false
+              responsive: ''
+            delete:
+              sortable: false
+              default_sort_order: asc
+              align: ''
+              separator: ''
+              empty_column: false
+              responsive: ''
+          override: true
+          sticky: false
+          summary: ''
+          empty_table: false
+          caption: ''
+          description: ''
+      row:
+        type: fields
+      query:
+        type: views_query
+        options:
+          query_comment: ''
+          disable_sql_rewrite: false
+          distinct: false
+          replica: false
+          query_tags: {  }
       relationships:
         uid:
           id: uid
@@ -500,49 +537,12 @@ display:
           relationship: none
           group_type: group
           admin_label: 'Linked Drupal user'
-          required: false
           plugin_id: standard
-      arguments:
-        provider_field:
-          id: provider_field
-          table: authmap
-          field: provider_field
-          relationship: none
-          group_type: group
-          admin_label: ''
-          default_action: ignore
-          exception:
-            value: all
-            title_enable: false
-            title: All
-          title_enable: true
-          title: 'Links for {{ arguments.provider_field }}'
-          default_argument_type: fixed
-          default_argument_options:
-            argument: ''
-          summary_options:
-            base_path: ''
-            items_per_page: 25
-            count: false
-            override: false
-          summary:
-            sort_order: asc
-            number_of_records: 0
-            format: default_summary
-          specify_validation: false
-          validate:
-            type: none
-            fail: 'not found'
-          validate_options: {  }
-          glossary: false
-          limit: 0
-          case: none
-          path_case: none
-          transform_dash: false
-          break_phrase: false
-          plugin_id: string
-      display_extenders: {  }
+          required: false
       show_admin_links: false
+      header: {  }
+      footer: {  }
+      display_extenders: {  }
     cache_metadata:
       max-age: -1
       contexts:
@@ -552,9 +552,9 @@ display:
         - user.permissions
       tags: {  }
   page:
-    display_plugin: page
     id: page
     display_title: Page
+    display_plugin: page
     position: 1
     display_options:
       display_extenders: {  }
@@ -563,11 +563,11 @@ display:
         type: tab
         title: External
         description: ''
-        expanded: false
-        parent: entity.user.collection
         weight: 20
-        context: '0'
+        expanded: false
         menu_name: admin
+        parent: entity.user.collection
+        context: '0'
     cache_metadata:
       max-age: -1
       contexts:

--- a/config/sync/views.view.samlauth_map.yml
+++ b/config/sync/views.view.samlauth_map.yml
@@ -17,104 +17,12 @@ base_table: authmap
 base_field: ''
 display:
   default:
-    display_plugin: default
     id: default
     display_title: Master
+    display_plugin: default
     position: 0
     display_options:
-      access:
-        type: perm
-        options:
-          perm: 'configure saml'
-      cache:
-        type: none
-        options: {  }
-      query:
-        type: views_query
-        options:
-          disable_sql_rewrite: false
-          distinct: false
-          replica: false
-          query_comment: ''
-          query_tags: {  }
-      exposed_form:
-        type: basic
-        options:
-          submit_button: Apply
-          reset_button: false
-          reset_button_label: Reset
-          exposed_sorts_label: 'Sort by'
-          expose_sort_order: true
-          sort_asc_label: Asc
-          sort_desc_label: Desc
-      pager:
-        type: mini
-        options:
-          items_per_page: 50
-          offset: 0
-          id: 0
-          total_pages: null
-          expose:
-            items_per_page: false
-            items_per_page_label: 'Items per page'
-            items_per_page_options: '5, 10, 25, 50'
-            items_per_page_options_all: false
-            items_per_page_options_all_label: '- All -'
-            offset: false
-            offset_label: Offset
-          tags:
-            previous: ‹‹
-            next: ››
-          pagination_heading_level: h4
-      style:
-        type: table
-        options:
-          grouping: {  }
-          row_class: ''
-          default_row_class: true
-          override: true
-          sticky: false
-          caption: ''
-          summary: ''
-          description: ''
-          columns:
-            authname: authname
-            uid: uid
-            name: name
-            delete: delete
-          info:
-            authname:
-              sortable: true
-              default_sort_order: asc
-              align: ''
-              separator: ''
-              empty_column: false
-              responsive: ''
-            uid:
-              sortable: true
-              default_sort_order: asc
-              align: ''
-              separator: ''
-              empty_column: false
-              responsive: ''
-            name:
-              sortable: true
-              default_sort_order: asc
-              align: ''
-              separator: ''
-              empty_column: false
-              responsive: ''
-            delete:
-              sortable: false
-              default_sort_order: asc
-              align: ''
-              separator: ''
-              empty_column: false
-              responsive: ''
-          default: authname
-          empty_table: false
-      row:
-        type: fields
+      title: 'SAML Authentication Links'
       fields:
         authname:
           id: authname
@@ -123,6 +31,7 @@ display:
           relationship: none
           group_type: group
           admin_label: ''
+          plugin_id: standard
           label: 'SAML IdP Unique ID'
           exclude: false
           alter:
@@ -164,7 +73,6 @@ display:
           hide_empty: false
           empty_zero: false
           hide_alter_empty: true
-          plugin_id: standard
         uid:
           id: uid
           table: authmap
@@ -172,6 +80,7 @@ display:
           relationship: none
           group_type: group
           admin_label: ''
+          plugin_id: numeric
           label: 'Drupal User ID'
           exclude: false
           alter:
@@ -221,7 +130,6 @@ display:
           format_plural_string: !!binary MQNAY291bnQ=
           prefix: ''
           suffix: ''
-          plugin_id: numeric
         name:
           id: name
           table: users_field_data
@@ -229,6 +137,9 @@ display:
           relationship: uid
           group_type: group
           admin_label: ''
+          entity_type: user
+          entity_field: name
+          plugin_id: field
           label: 'Drupal User Name'
           exclude: false
           alter:
@@ -284,9 +195,6 @@ display:
           multi_type: separator
           separator: ', '
           field_api_classes: false
-          entity_type: user
-          entity_field: name
-          plugin_id: field
         delete:
           id: delete
           table: authmap
@@ -294,6 +202,7 @@ display:
           relationship: none
           group_type: group
           admin_label: ''
+          plugin_id: samlauth_link_delete
           label: delete
           exclude: false
           alter:
@@ -338,7 +247,56 @@ display:
           text: delete
           output_url_as_text: false
           absolute: false
-          plugin_id: samlauth_link_delete
+      pager:
+        type: mini
+        options:
+          offset: 0
+          pagination_heading_level: h4
+          items_per_page: 50
+          total_pages: null
+          id: 0
+          tags:
+            next: ››
+            previous: ‹‹
+          expose:
+            items_per_page: false
+            items_per_page_label: 'Items per page'
+            items_per_page_options: '5, 10, 25, 50'
+            items_per_page_options_all: false
+            items_per_page_options_all_label: '- All -'
+            offset: false
+            offset_label: Offset
+      exposed_form:
+        type: basic
+        options:
+          submit_button: Apply
+          reset_button: false
+          reset_button_label: Reset
+          exposed_sorts_label: 'Sort by'
+          expose_sort_order: true
+          sort_asc_label: Asc
+          sort_desc_label: Desc
+      access:
+        type: perm
+        options:
+          perm: 'configure saml'
+      cache:
+        type: none
+        options: {  }
+      empty:
+        area_text_custom:
+          id: area_text_custom
+          table: views
+          field: area_text_custom
+          relationship: none
+          group_type: group
+          admin_label: ''
+          plugin_id: text_custom
+          empty: true
+          content: 'No links (from SAML Authentication ID to Drupal user)  found.'
+          tokenize: false
+      sorts: {  }
+      arguments: {  }
       filters:
         authname:
           id: authname
@@ -347,6 +305,7 @@ display:
           relationship: none
           group_type: group
           admin_label: ''
+          plugin_id: string
           operator: starts
           value: ''
           group: 1
@@ -382,7 +341,6 @@ display:
             default_group: All
             default_group_multiple: {  }
             group_items: {  }
-          plugin_id: string
         uid:
           id: uid
           table: users_field_data
@@ -390,6 +348,9 @@ display:
           relationship: uid
           group_type: group
           admin_label: ''
+          entity_type: user
+          entity_field: uid
+          plugin_id: user_name
           operator: in
           value: {  }
           group: 1
@@ -425,9 +386,6 @@ display:
             default_group: All
             default_group_multiple: {  }
             group_items: {  }
-          entity_type: user
-          entity_field: uid
-          plugin_id: user_name
         provider_field:
           id: provider_field
           table: authmap
@@ -435,6 +393,7 @@ display:
           relationship: none
           group_type: group
           admin_label: ''
+          plugin_id: string
           operator: '='
           value: samlauth
           group: 1
@@ -466,23 +425,63 @@ display:
             default_group: All
             default_group_multiple: {  }
             group_items: {  }
-          plugin_id: string
-      sorts: {  }
-      title: 'SAML Authentication Links'
-      header: {  }
-      footer: {  }
-      empty:
-        area_text_custom:
-          id: area_text_custom
-          table: views
-          field: area_text_custom
-          relationship: none
-          group_type: group
-          admin_label: ''
-          empty: true
-          tokenize: false
-          content: 'No links (from SAML Authentication ID to Drupal user)  found.'
-          plugin_id: text_custom
+      style:
+        type: table
+        options:
+          grouping: {  }
+          row_class: ''
+          default_row_class: true
+          columns:
+            authname: authname
+            uid: uid
+            name: name
+            delete: delete
+          default: authname
+          info:
+            authname:
+              sortable: true
+              default_sort_order: asc
+              align: ''
+              separator: ''
+              empty_column: false
+              responsive: ''
+            uid:
+              sortable: true
+              default_sort_order: asc
+              align: ''
+              separator: ''
+              empty_column: false
+              responsive: ''
+            name:
+              sortable: true
+              default_sort_order: asc
+              align: ''
+              separator: ''
+              empty_column: false
+              responsive: ''
+            delete:
+              sortable: false
+              default_sort_order: asc
+              align: ''
+              separator: ''
+              empty_column: false
+              responsive: ''
+          override: true
+          sticky: false
+          summary: ''
+          empty_table: false
+          caption: ''
+          description: ''
+      row:
+        type: fields
+      query:
+        type: views_query
+        options:
+          query_comment: ''
+          disable_sql_rewrite: false
+          distinct: false
+          replica: false
+          query_tags: {  }
       relationships:
         uid:
           id: uid
@@ -491,11 +490,12 @@ display:
           relationship: none
           group_type: group
           admin_label: 'Linked Drupal user'
-          required: false
           plugin_id: standard
-      arguments: {  }
-      display_extenders: {  }
+          required: false
       show_admin_links: false
+      header: {  }
+      footer: {  }
+      display_extenders: {  }
     cache_metadata:
       max-age: -1
       contexts:
@@ -506,9 +506,9 @@ display:
         - user.permissions
       tags: {  }
   page:
-    display_plugin: page
     id: page
     display_title: Page
+    display_plugin: page
     position: 1
     display_options:
       display_extenders: {  }
@@ -517,11 +517,11 @@ display:
         type: tab
         title: Links
         description: ''
-        expanded: false
-        parent: samlauth.samlauth_configure_form
         weight: 7
-        context: '0'
+        expanded: false
         menu_name: admin
+        parent: samlauth.samlauth_configure_form
+        context: '0'
     cache_metadata:
       max-age: -1
       contexts:

--- a/web/modules/custom/default_content_config/content/node/202c0f8c-2f2e-487a-8eed-e55fd949b41c.yml
+++ b/web/modules/custom/default_content_config/content/node/202c0f8c-2f2e-487a-8eed-e55fd949b41c.yml
@@ -4,6 +4,8 @@ _meta:
   uuid: 202c0f8c-2f2e-487a-8eed-e55fd949b41c
   bundle: short_post
   default_langcode: en
+  depends:
+    bbb973e8-d813-44a2-bafe-821d10f37014: node
 default:
   revision_uid:
     -
@@ -38,9 +40,17 @@ default:
     -
       value: 'A resource for developing accessible products.'
       format: html
+  field_external_url:
+    -
+      uri: 'https://accessibility.18f.gov/'
+      title: ''
+      options: {  }
   field_short_post_type:
     -
       value: resource
+  field_source:
+    -
+      entity: bbb973e8-d813-44a2-bafe-821d10f37014
   field_summary:
     -
       value: 'A resource for developing accessible products.'

--- a/web/modules/custom/default_content_config/content/node/30e4505c-8011-493a-a3e8-ad35ef95c29d.yml
+++ b/web/modules/custom/default_content_config/content/node/30e4505c-8011-493a-a3e8-ad35ef95c29d.yml
@@ -36,6 +36,11 @@ default:
       alias: ''
       langcode: en
       pathauto: 1
+  field_external_url:
+    -
+      uri: 'https://home.dotgov.gov'
+      title: ''
+      options: {  }
   field_short_post_type:
     -
       value: service

--- a/web/modules/custom/default_content_config/content/node/30f086db-8fb5-40e8-ae3f-58dc8be40f74.yml
+++ b/web/modules/custom/default_content_config/content/node/30f086db-8fb5-40e8-ae3f-58dc8be40f74.yml
@@ -36,6 +36,11 @@ default:
       alias: ''
       langcode: en
       pathauto: 1
+  field_external_url:
+    -
+      uri: 'https://www.fedramp.gov'
+      title: ''
+      options: {  }
   field_short_post_type:
     -
       value: news

--- a/web/modules/custom/default_content_config/content/node/3c4bcc2c-26ae-4263-86c0-b770851f8e95.yml
+++ b/web/modules/custom/default_content_config/content/node/3c4bcc2c-26ae-4263-86c0-b770851f8e95.yml
@@ -40,6 +40,11 @@ default:
     -
       value: 'Get started making usability fixes to your website or product.'
       format: html
+  field_external_url:
+    -
+      uri: 'https://digital.gov/event/2018/06/14/usability-testing-with-steve-krug/'
+      title: ''
+      options: {  }
   field_short_post_type:
     -
       value: resource

--- a/web/modules/custom/default_content_config/content/node/853969b8-5390-4fe2-865a-c645aa81d1fd.yml
+++ b/web/modules/custom/default_content_config/content/node/853969b8-5390-4fe2-865a-c645aa81d1fd.yml
@@ -41,6 +41,11 @@ default:
     -
       value: 'The mandate to be agile is everywhere. But agile isn’t an on-off switch. It’s a skill and a mindset that is developed over time, through dedicated work, open teams, and lots (and lots) of practice'
       format: html
+  field_external_url:
+    -
+      uri: 'https://18f.gsa.gov/2019/05/29/you-might-not-be-as-agile-as-you-think-you-are/'
+      title: ''
+      options: {  }
   field_short_post_type:
     -
       value: news

--- a/web/modules/custom/default_content_config/content/node/88a30df6-80b5-4887-bdb7-6ffb12259ac9.yml
+++ b/web/modules/custom/default_content_config/content/node/88a30df6-80b5-4887-bdb7-6ffb12259ac9.yml
@@ -40,6 +40,11 @@ default:
     -
       value: 'At the Department of Justice, Access DOJ and the Office of the Pardon Attorney (PARDON) partnered to simplify and streamline the presidential pardon application process. By conducting usability testing and gathering feedback, they identified key issues wi'
       format: html
+  field_external_url:
+    -
+      uri: 'https://www.justice.gov/atj/access-doj/case-studies/removing-barriers-applying-presidential-pardon'
+      title: ''
+      options: {  }
   field_short_post_type:
     -
       value: news

--- a/web/modules/custom/default_content_config/content/node/8ba0f0bd-d728-4df0-bb05-28766df7a1c0.yml
+++ b/web/modules/custom/default_content_config/content/node/8ba0f0bd-d728-4df0-bb05-28766df7a1c0.yml
@@ -40,6 +40,11 @@ default:
     -
       value: "18F's Alan Atlas and Alan Brouilette cover the fundamentals of Agile."
       format: html
+  field_external_url:
+    -
+      uri: 'https://digital.gov/event/2019/11/04/foundations-agile-i/'
+      title: ''
+      options: {  }
   field_short_post_type:
     -
       value: resource

--- a/web/modules/custom/default_content_config/content/node/d22455bc-ccf3-4079-a2bb-ecf67310af4b.yml
+++ b/web/modules/custom/default_content_config/content/node/d22455bc-ccf3-4079-a2bb-ecf67310af4b.yml
@@ -36,6 +36,11 @@ default:
       alias: ''
       langcode: en
       pathauto: 1
+  field_external_url:
+    -
+      uri: 'https://www.coe.gsa.gov'
+      title: ''
+      options: {  }
   field_short_post_type:
     -
       value: service

--- a/web/modules/custom/default_content_config/content/node/ea91eff1-f23a-4efc-a197-2606f95ced68.yml
+++ b/web/modules/custom/default_content_config/content/node/ea91eff1-f23a-4efc-a197-2606f95ced68.yml
@@ -36,6 +36,11 @@ default:
       alias: ''
       langcode: en
       pathauto: 1
+  field_external_url:
+    -
+      uri: 'https://www.usagov.com'
+      title: ''
+      options: {  }
   field_short_post_type:
     -
       value: service


### PR DESCRIPTION
<!-- Delete any detail that does not apply to this PR! -->

## Jira ticket
[DIGITAL-107](https://cm-jira.usa.gov/browse/DIGITAL-107)

## Purpose
Adds the `external_url` field to the short post content type, this was missed during the initial setup.
Updated default content short posts with URL.

## Deployment and testing




### QA/Testing instructions

Given I click the short post content from the menu
When I visit the create short page page
Then I should see the external URL field in the form

## Checklist for the Developer

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask for help! -->
- [x] A link to the JIRA ticket has been included above.
- [x] No merge conflicts exist with the target branch.
- [x] Automated tests have passed on this PR.
- [x] A reviewer has been designated.
- [x] Deployment and testing steps have been documented above, if applicable.

## Checklist for the Peer Reviewers

- [ ] The file changes are relevant to the task objective.
- [ ] Code is readable and includes appropriate commenting.
- [ ] Code standards and best practices are followed.
- [ ] QA/Test steps were successfully completed, if applicable.
- [ ] Applicable logs are free of errors.

<!--
Before opening this PR, make sure you’ve done whichever of these applies to you:
- Branch is up-to-date and includes latest from `develop`
- Target branch is correct
- You have ran code standards locally before assigning -`./robo.sh validate:all`
- PR is clear in both the reason it was opened and how the reviewer can confirm the work is done
-->
