### PR TITLE
DIGITAL-243: Pagination Template

### DIFF
--- a/web/themes/custom/digital_gov/templates/system/pager.html.twig
+++ b/web/themes/custom/digital_gov/templates/system/pager.html.twig
@@ -1,0 +1,102 @@
+{#
+/**
+ * @file
+ * Default theme implementation to display a pager.
+ *
+ * Available variables:
+ * - heading_id: Pagination heading ID.
+ * - pagination_heading_level: The heading level to use for the pager.
+ * - items: List of pager items.
+ *   The list is keyed by the following elements:
+ *   - first: Item for the first page; not present on the first page of results.
+ *   - previous: Item for the previous page; not present on the first page
+ *     of results.
+ *   - next: Item for the next page; not present on the last page of results.
+ *   - last: Item for the last page; not present on the last page of results.
+ *   - pages: List of pages, keyed by page number.
+ *   Sub-sub elements:
+ *   items.first, items.previous, items.next, items.last, and each item inside
+ *   items.pages contain the following elements:
+ *   - href: URL with appropriate query parameters for the item.
+ *   - attributes: A keyed list of HTML attributes for the item.
+ *   - text: The visible text used for the item link, such as "‹ Previous"
+ *     or "Next ›".
+ * - current: The page number of the current page.
+ * - ellipses: If there are more pages than the quantity allows, then an
+ *   ellipsis before or after the listed pages may be present.
+ *   - previous: Present if the currently visible list of pages does not start
+ *     at the first page.
+ *   - next: Present if the visible list of pages ends before the last page.
+ *
+ * @see template_preprocess_pager()
+ *
+ * @ingroup themeable
+ */
+#}
+{% if items %}
+  <nav class="pager" role="navigation" aria-labelledby="{{ heading_id }}">
+    <{{ pagination_heading_level }} id="{{ heading_id }}" class="visually-hidden">{{ 'Pagination'|t }}</{{ pagination_heading_level }}>
+    <ul class="pager__items js-pager__items">
+      {# Print first item if we are not on the first page. #}
+      {% if items.first %}
+        <li class="pager__item pager__item--first">
+          <a href="{{ items.first.href }}" title="{{ 'Go to first page'|t }}"{{ items.first.attributes|without('href', 'title') }}>
+            <span class="visually-hidden">{{ 'First page'|t }}</span>
+            <span aria-hidden="true">{{ items.first.text|default('« First'|t) }}</span>
+          </a>
+        </li>
+      {% endif %}
+      {# Print previous item if we are not on the first page. #}
+      {% if items.previous %}
+        <li class="pager__item pager__item--previous">
+          <a href="{{ items.previous.href }}" title="{{ 'Go to previous page'|t }}" rel="prev"{{ items.previous.attributes|without('href', 'title', 'rel') }}>
+            <span class="visually-hidden">{{ 'Previous page'|t }}</span>
+            <span aria-hidden="true">{{ items.previous.text|default('‹ Previous'|t) }}</span>
+          </a>
+        </li>
+      {% endif %}
+      {# Add an ellipsis if there are further previous pages. #}
+      {% if ellipses.previous %}
+        <li class="pager__item pager__item--ellipsis" role="presentation">&hellip;</li>
+      {% endif %}
+      {# Now generate the actual pager piece. #}
+      {% for key, item in items.pages %}
+        <li class="pager__item{{ current == key ? ' is-active' : '' }}">
+          {% if current == key %}
+            {% set title = 'Current page'|t %}
+          {% else %}
+            {% set title = 'Go to page @key'|t({'@key': key}) %}
+          {% endif %}
+          <a href="{{ item.href }}" title="{{ title }}"{{ item.attributes|without('href', 'title') }}>
+            <span class="visually-hidden">
+              {{ 'Page'|t }}
+            </span>
+            {{- key -}}
+          </a>
+        </li>
+      {% endfor %}
+      {# Add an ellipsis if there are further next pages. #}
+      {% if ellipses.next %}
+        <li class="pager__item pager__item--ellipsis" role="presentation">&hellip;</li>
+      {% endif %}
+      {# Print next item if we are not on the last page. #}
+      {% if items.next %}
+        <li class="pager__item pager__item--next">
+          <a href="{{ items.next.href }}" title="{{ 'Go to next page'|t }}" rel="next"{{ items.next.attributes|without('href', 'title', 'rel') }}>
+            <span class="visually-hidden">{{ 'Next page'|t }}</span>
+            <span aria-hidden="true">{{ items.next.text|default('Next ›'|t) }}</span>
+          </a>
+        </li>
+      {% endif %}
+      {# Print last item if we are not on the last page. #}
+      {% if items.last %}
+        <li class="pager__item pager__item--last">
+          <a href="{{ items.last.href }}" title="{{ 'Go to last page'|t }}"{{ items.last.attributes|without('href', 'title') }}>
+            <span class="visually-hidden">{{ 'Last page'|t }}</span>
+            <span aria-hidden="true">{{ items.last.text|default('Last »'|t) }}</span>
+          </a>
+        </li>
+      {% endif %}
+    </ul>
+  </nav>
+{% endif %}

--- a/web/themes/custom/digital_gov/templates/system/pager.html.twig
+++ b/web/themes/custom/digital_gov/templates/system/pager.html.twig
@@ -34,66 +34,82 @@
  */
 #}
 {% if items %}
-  <nav class="pager" role="navigation" aria-labelledby="{{ heading_id }}">
+  <nav role="navigation" aria-labelledby="{{ heading_id }}">
     <{{ pagination_heading_level }} id="{{ heading_id }}" class="visually-hidden">{{ 'Pagination'|t }}</{{ pagination_heading_level }}>
-    <ul class="pager__items js-pager__items">
+    <ul class="pagination">
       {# Print first item if we are not on the first page. #}
       {% if items.first %}
-        <li class="pager__item pager__item--first">
-          <a href="{{ items.first.href }}" title="{{ 'Go to first page'|t }}"{{ items.first.attributes|without('href', 'title') }}>
-            <span class="visually-hidden">{{ 'First page'|t }}</span>
-            <span aria-hidden="true">{{ items.first.text|default('« First'|t) }}</span>
-          </a>
-        </li>
+        <li class="pagination-first">
+        <a href="{{ items.first.href }}" aria-label="{{ 'First page'|t }}">
+          <svg
+            class="usa-icon dg-icon dg-icon--large"
+            aria-hidden="true"
+            focusable="false"
+            role="img"
+          >
+            <use
+              xlink:href="{{ drupal_url('/' ~ active_theme_path() ~ '/static/digitalgov/img/sprite.svg#first_page') }}"
+            ></use>
+          </svg>
+        </a>
+      </li>
       {% endif %}
       {# Print previous item if we are not on the first page. #}
       {% if items.previous %}
-        <li class="pager__item pager__item--previous">
-          <a href="{{ items.previous.href }}" title="{{ 'Go to previous page'|t }}" rel="prev"{{ items.previous.attributes|without('href', 'title', 'rel') }}>
-            <span class="visually-hidden">{{ 'Previous page'|t }}</span>
-            <span aria-hidden="true">{{ items.previous.text|default('‹ Previous'|t) }}</span>
+        <li class="pagination-previous">
+          <a href="{{ items.previous.href }}" aria-label="{{ 'Previous page'|t }}">
+            <svg
+              class="usa-icon dg-icon dg-icon--standard"
+              aria-hidden="true"
+              focusable="false"
+              role="img"
+            >
+              <use
+                xlink:href="{{ drupal_url('/' ~ active_theme_path() ~ '/static/digitalgov/img/sprite.svg#arrow_back') }}"
+              ></use>
+            </svg>
           </a>
         </li>
       {% endif %}
-      {# Add an ellipsis if there are further previous pages. #}
-      {% if ellipses.previous %}
-        <li class="pager__item pager__item--ellipsis" role="presentation">&hellip;</li>
-      {% endif %}
       {# Now generate the actual pager piece. #}
       {% for key, item in items.pages %}
-        <li class="pager__item{{ current == key ? ' is-active' : '' }}">
-          {% if current == key %}
-            {% set title = 'Current page'|t %}
-          {% else %}
-            {% set title = 'Go to page @key'|t({'@key': key}) %}
-          {% endif %}
-          <a href="{{ item.href }}" title="{{ title }}"{{ item.attributes|without('href', 'title') }}>
-            <span class="visually-hidden">
-              {{ 'Page'|t }}
-            </span>
+        <li class="page {{ current == key ? ' active' : '' }}">
+          <a href="{{ item.href }}" class="pagination__link">
             {{- key -}}
           </a>
         </li>
       {% endfor %}
-      {# Add an ellipsis if there are further next pages. #}
-      {% if ellipses.next %}
-        <li class="pager__item pager__item--ellipsis" role="presentation">&hellip;</li>
-      {% endif %}
       {# Print next item if we are not on the last page. #}
       {% if items.next %}
-        <li class="pager__item pager__item--next">
-          <a href="{{ items.next.href }}" title="{{ 'Go to next page'|t }}" rel="next"{{ items.next.attributes|without('href', 'title', 'rel') }}>
-            <span class="visually-hidden">{{ 'Next page'|t }}</span>
-            <span aria-hidden="true">{{ items.next.text|default('Next ›'|t) }}</span>
+        <li class="pagination-next">
+          <a href="{{ items.next.href }}" aria-label="{{ 'Next page'|t }}">
+            <svg
+              class="usa-icon dg-icon dg-icon--standard"
+              aria-hidden="true"
+              focusable="false"
+              role="img"
+            >
+              <use
+                xlink:href="{{ drupal_url('/' ~ active_theme_path() ~ '/static/digitalgov/img/sprite.svg#arrow_forward') }}"
+              ></use>
+            </svg>
           </a>
         </li>
       {% endif %}
       {# Print last item if we are not on the last page. #}
       {% if items.last %}
-        <li class="pager__item pager__item--last">
-          <a href="{{ items.last.href }}" title="{{ 'Go to last page'|t }}"{{ items.last.attributes|without('href', 'title') }}>
-            <span class="visually-hidden">{{ 'Last page'|t }}</span>
-            <span aria-hidden="true">{{ items.last.text|default('Last »'|t) }}</span>
+        <li class="pagination-last">
+          <a href="{{ items.last.href }}" aria-label="{{ 'Last page'|t }}">
+            <svg
+              class="usa-icon dg-icon dg-icon--large"
+              aria-hidden="true"
+              focusable="false"
+              role="img"
+            >
+              <use
+                xlink:href="{{ drupal_url('/' ~ active_theme_path() ~ '/static/digitalgov/img/sprite.svg#last_page') }}"
+              ></use>
+            </svg>
           </a>
         </li>
       {% endif %}


### PR DESCRIPTION
<!-- Delete any detail that does not apply to this PR! -->

## Jira ticket
[DIGITAL-243](https://cm-jira.usa.gov/browse/DIGITAL-243)

## Purpose
Bring pagination markup into new Drupal templates so styles match Hugo site

## Deployment and testing

### Local Setup

`lando cr`

### QA/Testing instructions

1. Navigate to `/news`
2. Compare the pager on `/news` to production `https://digital.gov/news/`
**Note**: If you need to see more than 5 pages in the pager to test, temporarily update the news_and_events view so there is 1 in "Items to display"

## Checklist for the Developer

- [x] A link to the JIRA ticket has been included above.
- [x] No merge conflicts exist with the target branch.
- [x] Automated tests have passed on this PR.
- [x] A reviewer has been designated.
- [x] Deployment and testing steps have been documented above, if applicable.

## Checklist for the Peer Reviewers

- [ ] The file changes are relevant to the task objective.
- [ ] Code is readable and includes appropriate commenting.
- [ ] Code standards and best practices are followed.
- [ ] QA/Test steps were successfully completed, if applicable.
- [ ] Applicable logs are free of errors.

<!--
Before opening this PR, make sure you’ve done whichever of these applies to you:
- Branch is up-to-date and includes latest from `develop`
- Target branch is correct
- You have ran code standards locally before assigning -`./robo.sh validate:all`
- PR is clear in both the reason it was opened and how the reviewer can confirm the work is done
-->
