### PR TITLE
DIGITAL-345: Update display of Embedded Media Document to use media name

### DIFF
--- a/web/themes/custom/digital_gov/templates/media/media--document.html.twig
+++ b/web/themes/custom/digital_gov/templates/media/media--document.html.twig
@@ -1,0 +1,30 @@
+{#
+/**
+ * @file
+ * Theme override to display a media item.
+ *
+ * Available variables:
+ * - name: Name of the media.
+ * - content: Media content.
+ *
+ * @see template_preprocess_media()
+ *
+ * @ingroup themeable
+ */
+#}
+{%
+  set classes = [
+    'media',
+    'media--type-' ~ media.bundle()|clean_class,
+    not media.isPublished() ? 'media--unpublished',
+    view_mode ? 'media--view-mode-' ~ view_mode|clean_class,
+  ]
+%}
+{% set document_path = media.field_media_file.entity.uri.value|file_url %}
+{% set document_filemime = media.field_media_file.entity.filemime.value %}
+
+<div{{ attributes.addClass(classes) }}>
+  {% if content %}
+    <a href="{{ document_path }}" class="usa-link" type="{{ document_filemime }}" >{{ name }}</a>
+  {% endif %}
+</div>


### PR DESCRIPTION
<!-- Delete any detail that does not apply to this PR! -->

## Jira ticket

[DIGITAL-345](https://cm-jira.usa.gov/browse/DIGITAL-345)

## Purpose

**Default functionality for Media Type: Documents**

WHEN a media document is displayed (including if it is embedded via a WYSIWYG)
THEN the embed will display The **Media Name** and will href will be **Path to the File**
AND it will **not** display file size (if you see file size, then it should be manually entered as part of the media name)

## Deployment and testing

### Local Setup

`lando drush cr`

### QA/Testing instructions

1. Visit [Media Testing Item](/media/16/edit) and take note of the "Name"
2. Compare the Name field to the name field embedded here [short code demo page](http://digitalgov.lndo.site/short-code-test-page)

-or-

1. Create a media document and enter a name that is different than the file name
2. Create a node and embed the media document into the node
3. View the node and you should see the document name and not the file name

Note: if you try to create a Document on the fly via the media library modal, you will not be able to add the document Name. Until this is fixed, this will be a two step process.

## Checklist for the Developer

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask for help! -->
- [x] A link to the JIRA ticket has been included above.
- [x] No merge conflicts exist with the target branch.
- [x] Automated tests have passed on this PR.
- [x] A reviewer has been designated.
- [x] Deployment and testing steps have been documented above, if applicable.

## Checklist for the Peer Reviewers

- [x] The file changes are relevant to the task objective.
- [x] Code is readable and includes appropriate commenting.
- [x] Code standards and best practices are followed.
- [x] QA/Test steps were successfully completed, if applicable.
- [x] Applicable logs are free of errors.

<!--
Before opening this PR, make sure you’ve done whichever of these applies to you:
- Branch is up-to-date and includes latest from `develop`
- Target branch is correct
- You have ran code standards locally before assigning -`./robo.sh validate:all`
- PR is clear in both the reason it was opened and how the reviewer can confirm the work is done
-->
