### PR TITLE
DIGITAL-440: Search.gov form in the header

### DIFF
--- a/web/themes/custom/digital_gov/templates/block/block--site-wrapper-header.html.twig
+++ b/web/themes/custom/digital_gov/templates/block/block--site-wrapper-header.html.twig
@@ -68,63 +68,16 @@
         <img src="{{ drupal_url(theme_path ~ '/static/digitalgov/img/close.svg') }}" alt="close" />
       </button>
       {{ drupal_menu('main') }}
-      [secondary Menu placeholder] (This is just /subscribe and search, maybe not a menu)]
-      {# NOT-MIGRATED
-      {{- $currentNode := . -}}
-      {{- $menuClasses := "usa-nav__primary-item" -}}
-      <ul class="usa-nav__primary usa-accordion">
-
-        {{- range .Site.Menus.primary -}}
-        <li
-            class="usa-nav__primary-item {{ if or ($currentNode.IsMenuCurrent "primary" .) ($currentNode.HasMenuCurrent "primary" .) }}
-              usa-current
-            {{ end }}"
-        >
-          <a class="usa-nav__link" href="{{- .URL -}}"
-          ><span>{{- .Name -}}</span></a
-          >
-        </li>
-        {{- end -}}
-      </ul>
-      <!-- .nav -->
-
       <div class="usa-nav__secondary">
         <ul class="usa-nav__secondary-links">
           <li class="usa-nav__secondary-item">
-            <a href="{{- "subscribe" | relURL -}}"
+            <a href="{{ drupal_url('subscribe') }}"
             ><span>Subscribe to our newsletter</span></a
             >
           </li>
         </ul>
-
-        <form
-            accept-charset="UTF-8"
-            action="https://find.digitalgov.gov/search"
-            id="search_form"
-            method="get"
-            class="usa-search usa-search--small"
-        >
-          <input name="utf8" type="hidden" value="&#x2713;" />
-          <input
-              id="affiliate"
-              name="affiliate"
-              type="hidden"
-              value="digitalgov"
-          />
-          <div role="search">
-            <label class="usa-sr-only" for="query">Search small</label>
-            <input class="usa-input" id="query" type="search" name="query" />
-            <button class="usa-button" name="commit" type="submit">
-              <img
-                  src="{{- "uswds/img/usa-icons-bg/search--white.svg" | relURL -}}"
-                  class="usa-search__submit-icon"
-                  alt="Search"
-              />
-            </button>
-          </div>
-        </form>
+        {{ include('@digital_gov/partials/search-gov-form.html.twig') }}
       </div>
-      #}
     </div>
   </nav>
 </header>

--- a/web/themes/custom/digital_gov/templates/partials/search-gov-form.html.twig
+++ b/web/themes/custom/digital_gov/templates/partials/search-gov-form.html.twig
@@ -1,0 +1,32 @@
+{# ====
+Search.gov form displayed in the header
+
+The form action (https://find.digitalgov.gov/search) is a masked domain for search.gov (https://search.usa.gov/search).
+The Search.gov program website used to be hosted on search.digitalgov.gov, so Digitalgov set up masking for 'find' to get around this issue.
+#}
+<form
+  accept-charset="UTF-8"
+  action="https://find.digitalgov.gov/search"
+  id="search_form"
+  method="get"
+  class="usa-search usa-search--small"
+>
+  <input name="utf8" type="hidden" value="&#x2713;" />
+  <input
+    id="affiliate"
+    name="affiliate"
+    type="hidden"
+    value="digitalgov"
+  />
+  <div role="search">
+    <label class="usa-sr-only" for="query">Search small</label>
+    <input class="usa-input" id="query" type="search" name="query" />
+    <button class="usa-button" name="commit" type="submit">
+      <img
+        src="{{ drupal_url('/' ~ active_theme_path() ~ '/static/uswds/img/usa-icons-bg/search--white.svg') }}"
+        class="usa-search__submit-icon"
+        alt="Search"
+      />
+    </button>
+  </div>
+</form>


### PR DESCRIPTION
<!-- Delete any detail that does not apply to this PR! -->

## Jira ticket

[DIGITAL-440](https://cm-jira.usa.gov/browse/DIGITAL-440)

## Purpose

Added the following to the header of the site
- Search input form that will search search.gov
- "Subscribe to our newsletter" link above the search form

![image](https://github.com/user-attachments/assets/9d86d622-93ff-48d3-af2a-501fcccb551d)

## Deployment and testing

### Local Setup

`lando si`

### QA/Testing instructions

On header of any page of the site you should see:
- Search input form that will search search.gov via the URL https://find.digitalgov.gov/search
- "Subscribe to our newsletter" link above the search form 
    - link will go to 404 Error because that content does not exist yet.
    - If the "Subscribe to our newsletter" link color looks wrong that is because you are comparing a visited link to an unvisited link. 

Be sure to check that it shows in the responsive menu.

## Checklist for the Developer

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask for help! -->
- [x] A link to the JIRA ticket has been included above.
- [x] No merge conflicts exist with the target branch.
- [x] Automated tests have passed on this PR.
- [x] A reviewer has been designated.
- [x] Deployment and testing steps have been documented above, if applicable.

## Checklist for the Peer Reviewers

- [x] The file changes are relevant to the task objective.
- [x] Code is readable and includes appropriate commenting.
- [x] Code standards and best practices are followed.
- [x] QA/Test steps were successfully completed, if applicable.
- [x] Applicable logs are free of errors.

<!--
Before opening this PR, make sure you’ve done whichever of these applies to you:
- Branch is up-to-date and includes latest from `develop`
- Target branch is correct
- You have ran code standards locally before assigning -`./robo.sh validate:all`
- PR is clear in both the reason it was opened and how the reviewer can confirm the work is done
-->
