### PR TITLE
DIGITAL-472: Add Guide Landing to Sitemap

### DIFF
--- a/config/sync/xmlsitemap.settings.node.guide_landing.yml
+++ b/config/sync/xmlsitemap.settings.node.guide_landing.yml
@@ -1,0 +1,3 @@
+status: true
+priority: 1.0
+changefreq: 86400

--- a/web/modules/custom/convert_text/src/ConvertText.php
+++ b/web/modules/custom/convert_text/src/ConvertText.php
@@ -52,7 +52,6 @@ class ConvertText {
         // Rewrite links to prod domain to current one for internal links.
         // Remove preview directories in link paths.
         // Remove preview directories in path to uswds images.
-
         $html = str_replace([
           ' href="https://digital.gov/',
           ' href="/preview/gsa/digitalgov.gov/nl-json-endpoints/',
@@ -101,7 +100,7 @@ class ConvertText {
     $source_text = preg_replace('/\/svg>(\R|\s)+([A-Za-z0-9]+)/', '/svg>$2', $source_text);
     // Remove any line breaks, whitespace before a closing heading.
     $source_text = preg_replace('/(\R+|\s+)(<\/h[0-9]+>)/i', '$2', $source_text);
-    // Remove line breaks at the start of href
+    // Remove line breaks at the start of href.
     $source_text = preg_replace('/href="(\R|\s)+/', 'href="', $source_text);
 
     // When the source text has raw HTML, leading spaces are mistaken for

--- a/web/themes/custom/digital_gov/templates/node/node--short-post--collection-item.html.twig
+++ b/web/themes/custom/digital_gov/templates/node/node--short-post--collection-item.html.twig
@@ -67,5 +67,5 @@
   summary: content.field_summary|field_value,
   url: content.field_external_url|field_value,
   header_level: 2,
-  header_class: 'usa-collection__heading'
+  header_class: 'usa-collection__heading',
 }, with_context: false) }}


### PR DESCRIPTION
<!-- Delete any detail that does not apply to this PR! -->

## Jira ticket
[DIGITAL-472](https://cm-jira.usa.gov/browse/DIGITAL-472)

## Purpose

Added Guide Landing pages to the sitemap.

## Deployment and testing

### Local Setup

`lando si`

### QA/Testing instructions

1. Generate the sitemap - lando drush xmlsitemap:regenerate 
2. Check if /guides/hcd is on the sitemap or any other Guide Landing

## Checklist for the Developer

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask for help! -->
- [ ] A link to the JIRA ticket has been included above.
- [ ] No merge conflicts exist with the target branch.
- [ ] Automated tests have passed on this PR.
- [ ] A reviewer has been designated.
- [ ] Deployment and testing steps have been documented above, if applicable.

## Checklist for the Peer Reviewers

- [ ] The file changes are relevant to the task objective.
- [ ] Code is readable and includes appropriate commenting.
- [ ] Code standards and best practices are followed.
- [ ] QA/Test steps were successfully completed, if applicable.
- [ ] Applicable logs are free of errors.

<!--
Before opening this PR, make sure you’ve done whichever of these applies to you:
- Branch is up-to-date and includes latest from `develop`
- Target branch is correct
- You have ran code standards locally before assigning -`./robo.sh validate:all`
- PR is clear in both the reason it was opened and how the reviewer can confirm the work is done
-->
