### PR TITLE
DIGITAL-478: Add patch to make Sitewide alerts work with TOME

### DIFF
--- a/composer.patches.json
+++ b/composer.patches.json
@@ -27,6 +27,9 @@
     },
     "drupal/tome": {
       "/project/tome/issues/3511001: Stdout from drush commands stops additional HTML assets from being created": "https://www.drupal.org/files/issues/2025-03-04/tome-3511001-stdout-from-drush-commands-stops-additional-htmlassets-from-being-created-3.patch"
+    },
+    "drupal/sitewide_alert": {
+      "DIGITAL-478: Update Alerts display in Tome Static Build": "patches/sitewide_alert_cache_tome.patch"
     }
   }
 }

--- a/patches/sitewide_alert_cache_tome.patch
+++ b/patches/sitewide_alert_cache_tome.patch
@@ -1,0 +1,13 @@
+diff --git a/js/init.js b/js/init.js
+index 799fba6..c1a94e1 100644
+--- a/js/init.js
++++ b/js/init.js
+@@ -91,6 +91,7 @@
+         drupalSettings.path.baseUrl +
+         drupalSettings.path.pathPrefix
+       }sitewide_alert/load`,
++      {cache: 'reload'}
+     )
+       .then((res) => res.json())
+       .then(
+


### PR DESCRIPTION
<!-- Delete any detail that does not apply to this PR! -->

## Jira ticket

[DIGITAL-478](https://cm-jira.usa.gov/browse/DIGITAL-478)

## Purpose

Fix Sitewide alert caching with TOME

## Deployment and testing

### Local Setup

`lando rebuild -y && lando si`

### QA/Testing instructions

1. Create a Site Alert in the Drupal UI https://digitalgov.lndo.site/admin/content/sitewide_alert
2. Generate the static site - `./robo.sh drupal-project:export-content && ./robo.sh static` 
3. Visit the site and you will see the Site Alert appears on the page correctly.
4. Stop the static site
5. Update the Site alert in the Drupal UI https://digitalgov.lndo.site/admin/content/sitewide_alert
6. Generate the static site - `./robo.sh drupal-project:export-content && ./robo.sh static` 
7. Visit the site and you will see the site alert has updated
## Checklist for the Developer

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask for help! -->
- [x] A link to the JIRA ticket has been included above.
- [x] No merge conflicts exist with the target branch.
- [x] Automated tests have passed on this PR.
- [x] A reviewer has been designated.
- [x] Deployment and testing steps have been documented above, if applicable.

## Checklist for the Peer Reviewers

- [ ] The file changes are relevant to the task objective.
- [ ] Code is readable and includes appropriate commenting.
- [ ] Code standards and best practices are followed.
- [ ] QA/Test steps were successfully completed, if applicable.
- [ ] Applicable logs are free of errors.

<!--
Before opening this PR, make sure you’ve done whichever of these applies to you:
- Branch is up-to-date and includes latest from `develop`
- Target branch is correct
- You have ran code standards locally before assigning -`./robo.sh validate:all`
- PR is clear in both the reason it was opened and how the reviewer can confirm the work is done
-->
