### PR TITLE
DIGITAL-528:Glossary Accordion Bug

### DIFF
--- a/config/sync/views.view.glossary_sidebar.yml
+++ b/config/sync/views.view.glossary_sidebar.yml
@@ -61,12 +61,12 @@ display:
             trim: false
             preserve_tags: ''
             html: false
-          element_type: ''
+          element_type: '0'
           element_class: ''
           element_label_type: ''
           element_label_class: ''
           element_label_colon: false
-          element_wrapper_type: ''
+          element_wrapper_type: '0'
           element_wrapper_class: ''
           element_default_classes: false
           empty: ''
@@ -127,12 +127,12 @@ display:
             trim: false
             preserve_tags: ''
             html: false
-          element_type: ''
+          element_type: '0'
           element_class: ''
           element_label_type: ''
           element_label_class: ''
           element_label_colon: false
-          element_wrapper_type: ''
+          element_wrapper_type: '0'
           element_wrapper_class: ''
           element_default_classes: false
           empty: ''

--- a/web/themes/custom/digital_gov/templates/views/views-view-field--glossary-sidebar--accordion--name.html.twig
+++ b/web/themes/custom/digital_gov/templates/views/views-view-field--glossary-sidebar--accordion--name.html.twig
@@ -1,4 +1,4 @@
-<button class="dg-glossary__term" aria-controls="glossary-term-0" aria-expanded="false">{{ output }}</button>
+<button class="dg-glossary__term" aria-controls="glossary-term-{{ row.index }}" aria-expanded="false">{{ output }}</button>
 <svg id="glossary-term-{{ row.index }}-icon" class="dg-glossary__icon usa-icon dg-icon dg-icon--large" aria-hidden="true" focusable="false" role="img">
   <use xlink:href="/{{ active_theme_path() }}/static/uswds/img/sprite.svg#expand_more"></use>
 </svg>


### PR DESCRIPTION
## Jira ticket

[DIGITAL-528](https://cm-jira.usa.gov/browse/DIGITAL-528)

## Purpose

The glossary accordion was opening the wrong item when clicked.

## Deployment and testing

### Local Setup

<!--Insert any required steps to take before beginning to test. Such as `lando rebuild`, rebuilding frontend or config updates needed to follow the testing steps.-->

### QA/Testing instructions

1. Nav to  https://digital-gov-static-dev.app.cloud.gov/guides/hcd
2. Click on "Glossary" and right side drawer pops out
3. Click on various accordion item

**Expected Result**: The accordion item that you click toggles open and closed when you click it

## Checklist for the Developer

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask for help! -->
- [x] A link to the JIRA ticket has been included above.
- [x] No merge conflicts exist with the target branch.
- [x] Automated tests have passed on this PR.
- [x] A reviewer has been designated.
- [x] Deployment and testing steps have been documented above, if applicable.

## Checklist for the Peer Reviewers

- [ ] The file changes are relevant to the task objective.
- [ ] Code is readable and includes appropriate commenting.
- [ ] Code standards and best practices are followed.
- [ ] QA/Test steps were successfully completed, if applicable.
- [ ] Applicable logs are free of errors.

<!--
Before opening this PR, make sure you’ve done whichever of these applies to you:
- Branch is up-to-date and includes latest from `develop`
- Target branch is correct
- You have ran code standards locally before assigning -`./robo.sh validate:all`
- PR is clear in both the reason it was opened and how the reviewer can confirm the work is done
-->
