### PR TITLE
DIGITAL-540: Updated resource topics list to use taxonomy weight for topics list and sort topics alphabetically

### DIFF
--- a/config/sync/views.view.resource_topics_list.yml
+++ b/config/sync/views.view.resource_topics_list.yml
@@ -228,6 +228,21 @@ display:
         options: {  }
       empty: {  }
       sorts:
+        weight:
+          id: weight
+          table: taxonomy_term_field_data
+          field: weight
+          relationship: field_resource_topics
+          group_type: group
+          admin_label: ''
+          entity_type: taxonomy_term
+          entity_field: weight
+          plugin_id: standard
+          order: ASC
+          expose:
+            label: ''
+            field_identifier: ''
+          exposed: false
         title:
           id: title
           table: node_field_data
@@ -338,7 +353,16 @@ display:
           distinct: false
           replica: false
           query_tags: {  }
-      relationships: {  }
+      relationships:
+        field_resource_topics:
+          id: field_resource_topics
+          table: node__field_resource_topics
+          field: field_resource_topics
+          relationship: none
+          group_type: group
+          admin_label: 'field_resource_topics: Taxonomy term'
+          plugin_id: standard
+          required: true
       header: {  }
       footer: {  }
       display_extenders: {  }


### PR DESCRIPTION
## Jira ticket
[DIGITAL-540](https://cm-jira.usa.gov/browse/DIGITAL-540)

## Purpose
Updates the sort order to use the taxonomy weight instead of alphabetical sort.

Should be:

1. Design
2. Data & Analysis
3. Operations
4. Content & Communication
5. Technology
6. Strategic Development

<details>
<summary>Screenshot</summary>


![Screen Shot 000040 on 2025-03-19](https://github.com/user-attachments/assets/96269cd6-733f-4b2e-8d5d-f292c864501a)


</details>

### QA/Testing instructions

<!--Insert steps to test and confirm the result meets the "definition of done".-->

## Checklist for the Developer

- [x] A link to the JIRA ticket has been included above.
- [x] No merge conflicts exist with the target branch.
- [x] Automated tests have passed on this PR.
- [x] A reviewer has been designated.
- [x] Deployment and testing steps have been documented above, if applicable.

## Checklist for the Peer Reviewers

- [ ] The file changes are relevant to the task objective.
- [ ] Code is readable and includes appropriate commenting.
- [ ] Code standards and best practices are followed.
- [ ] QA/Test steps were successfully completed, if applicable.
- [ ] Applicable logs are free of errors.

<!--
Before opening this PR, make sure you’ve done whichever of these applies to you:
- Branch is up-to-date and includes latest from `develop`
- Target branch is correct
- You have ran code standards locally before assigning -`./robo.sh validate:all`
- PR is clear in both the reason it was opened and how the reviewer can confirm the work is done
-->
