### PR TITLE
DIGITAL-523: Fix tome-breadcrumbs

### DIFF
--- a/web/modules/custom/dg_breadcrumb/dg_breadcrumb.module
+++ b/web/modules/custom/dg_breadcrumb/dg_breadcrumb.module
@@ -5,6 +5,7 @@
  * Primary module hooks for Digital.gov Breadcrumb module.
  */
 
+use Drupal\Core\Block\BlockPluginInterface;
 use Drupal\Core\Breadcrumb\Breadcrumb;
 use Drupal\Core\Link;
 use Drupal\Core\Routing\RouteMatchInterface;
@@ -62,4 +63,15 @@ function dg_breadcrumb_system_breadcrumb_alter(Breadcrumb &$breadcrumb, RouteMat
       break;
 
   }
+}
+
+/**
+ * Implements hook_block_build_alter().
+ */
+function dg_breadcrumb_block_build_system_breadcrumb_block_alter(array &$build, BlockPluginInterface $block) {
+  // Ensure drupal knows this block should be cached per path
+  // and when the menu changes.
+  $build['#cache']['contexts'][] = 'url.path';
+  $build['#cache']['contexts'][] = 'url.query_args';
+  $build['#cache']['tags'][] = 'config:system.menu.main';
 }


### PR DESCRIPTION
## Jira ticket

[DIGITAL-523](https://cm-jira.usa.gov/browse/DIGITAL-523)

## Purpose
Alters system breadcrumb block to cache per URL.

## Includes the following PRs that must be merged first

<!-- Optional: List any PRs that must be merged before this one can be reviewed. -->

## Deployment and testing

### Local Setup

`lando si` should be sufficient for your environment. The tricky thing for testing this is to **enable** the config settings for cache bins.

1. Go to `/web/sites/default/settings.local.php`
2. Comment out:
    - line 37 (leaving it enables dev twig debugging, disables render caching),
    - line 65 (render cache again),
    - line 87 (internal page cache),
    -  line 96 (dynamic page page), 

### QA/Testing instructions

Run `robo.sh static` to export the Drupal site to static files.

Verify that on the static pages:

- Event detail page has a breadcrumb where 2nd parent is "Events"
- Blog/News detail page has a breadcrumb where 2nd parent is "News"
- Resource detail page has a breadcrumb where 2nd parent is "Topics"
- Community detail page has a breadcrumb where 2nd parent is "Communities"

Guides, jobs, and authors don't have breadcrumbs.
<!--Insert steps to test and confirm the result meets the "definition of done".-->

## Checklist for the Developer

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask for help! -->
- [x] A link to the JIRA ticket has been included above.
- [x] No merge conflicts exist with the target branch.
- [x] Automated tests have passed on this PR.
- [x] A reviewer has been designated.

## Checklist for the Peer Reviewers

- [ ] The file changes are relevant to the task objective.
- [ ] Code is readable and includes appropriate commenting.
- [ ] Code standards and best practices are followed.
- [ ] QA/Test steps were successfully completed, if applicable.
- [ ] Applicable logs are free of errors.

<!--
Before opening this PR, make sure you’ve done whichever of these applies to you:
- Branch is up-to-date and includes latest from `develop`
- Target branch is correct
- You have ran code standards locally before assigning -`./robo.sh validate:all`
- PR is clear in both the reason it was opened and how the reviewer can confirm the work is done
-->
