### PR TITLE
DIGITAL-606: Update focus styles for banner buttons

### DIFF
--- a/web/themes/custom/digital_gov/css/new/_buttons.scss
+++ b/web/themes/custom/digital_gov/css/new/_buttons.scss
@@ -59,6 +59,11 @@ a.btn-home {
       @include u-border-bottom("2px", "black", "solid");
     }
   }
+
+  &:focus {
+    outline: .25rem solid #0395F0;
+    outline-offset: .25rem;
+  }
 }
 
 a.btn-sm {


### PR DESCRIPTION
## Jira ticket

[DIGITAL-606](https://cm-jira.usa.gov/browse/DIGITAL-606)

## Purpose

On homepage, in the banner, when the user focuses on a button using they keyboard, there is not enough contrast in the visual indication of focus. it needs to be 3:1 ratio
 

## Deployment and testing

### Local Setup

`lando fe`

### QA/Testing instructions

When you focus using your keyboard on the buttons in the homepage banner

![image](https://github.com/user-attachments/assets/889a17cd-ada9-4d3a-9c8d-195aa8ea34e3)

## Checklist for the Developer

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask for help! -->
- [x] A link to the JIRA ticket has been included above.
- [x] No merge conflicts exist with the target branch.
- [x] Automated tests have passed on this PR.
- [x] A reviewer has been designated.
- [x] Deployment and testing steps have been documented above, if applicable.

## Checklist for the Peer Reviewers

- [ ] The file changes are relevant to the task objective.
- [ ] Code is readable and includes appropriate commenting.
- [ ] Code standards and best practices are followed.
- [ ] QA/Test steps were successfully completed, if applicable.
- [ ] Applicable logs are free of errors.

<!--
Before opening this PR, make sure you’ve done whichever of these applies to you:
- Branch is up-to-date and includes latest from `develop`
- Target branch is correct
- You have ran code standards locally before assigning -`./robo.sh validate:all`
- PR is clear in both the reason it was opened and how the reviewer can confirm the work is done
-->
