### PR TITLE
DIGITAL-569: Appends fragment to pager links on /events to maintain s…

### DIFF
--- a/web/themes/custom/digital_gov/digital_gov.theme
+++ b/web/themes/custom/digital_gov/digital_gov.theme
@@ -408,3 +408,33 @@ function digital_gov_preprocess_node__landing_page__job_board(&$variables, $hook
   }
   $variables['job_board'] = $filtered_array;
 }
+
+/**
+ * Implements hook_preprocess_pager().
+ */
+function digital_gov_preprocess_pager(&$variables) {
+  // Appends fragment to pager links on /events to maintain scroll position.
+  $current_path = \Drupal::service('path.current')->getPath();
+  $alias = \Drupal::service('path_alias.manager')->getAliasByPath($current_path);
+
+  $anchor = '#events-past';
+
+  // Ensure we are only affecting the pager on the /events page.
+  if ($alias === '/events' && !empty($variables['items'])) {
+    // Iterate through all items in the pager.
+    foreach ($variables['items'] as $key => &$item) {
+      // Handle numbered pages separately from navigation items.
+      if ($key === 'pages') {
+        foreach ($item as &$page) {
+          if (isset($page['href'])) {
+            $page['href'] .= $anchor;
+          }
+        }
+      }
+      // Handle navigation items (first, previous, next, last).
+      elseif (isset($item['href'])) {
+        $item['href'] .= $anchor;
+      }
+    }
+  }
+}


### PR DESCRIPTION
## Jira ticket

[DIGITAL-569](https://cm-jira.usa.gov/browse/DIGITAL-569)

## Purpose

Append fragment to Past Events pager links on /events page to maintain scroll position when clicking a pager item.

## Deployment and testing

### Local Setup

`lando rebuild && lando si`

### QA/Testing instructions

There are not enough default content items to see the pagination when testing. You will need to adjust the number of items shown in the Past Event view (https://digitalgov.lndo.site/admin/structure/views/view/past_events) or add a bunch more events by running a migrate all locally.

The events page (https://digitalgov.lndo.site/events), Past events section should show pagination when you are over 20 past events.

When you click on a link in the pagination, `#events-past` should be appended to the href so that the user does not get pushed back up to the top of the page when they use the pager. This should work for numbers and for first, previous, next, last

## Checklist for the Developer

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask for help! -->
- [ ] A link to the JIRA ticket has been included above.
- [ ] No merge conflicts exist with the target branch.
- [ ] Automated tests have passed on this PR.
- [ ] A reviewer has been designated.
- [ ] Deployment and testing steps have been documented above, if applicable.

## Checklist for the Peer Reviewers

- [ ] The file changes are relevant to the task objective.
- [ ] Code is readable and includes appropriate commenting.
- [ ] Code standards and best practices are followed.
- [ ] QA/Test steps were successfully completed, if applicable.
- [ ] Applicable logs are free of errors.

<!--
Before opening this PR, make sure you’ve done whichever of these applies to you:
- Branch is up-to-date and includes latest from `develop`
- Target branch is correct
- You have ran code standards locally before assigning -`./robo.sh validate:all`
- PR is clear in both the reason it was opened and how the reviewer can confirm the work is done
-->
