### PR TITLE
DIGITAL-474: Correct the home default canonical meta tag

### DIFF
--- a/config/sync/metatag.metatag_defaults.front.yml
+++ b/config/sync/metatag.metatag_defaults.front.yml
@@ -7,6 +7,7 @@ _core:
 id: front
 label: 'Front page'
 tags:
+  canonical_url: '[site:base-url]'
   og_title: '[site:name]'
   og_url: '[site:base-url]'
   title: '[site:name] — Guidance on building better digital services in government'


### PR DESCRIPTION
<!-- Delete any detail that does not apply to this PR! -->

## Jira ticket

[DIGITAL-474](https://cm-jira.usa.gov/browse/DIGITAL-474)

## Purpose

Inaccurate meta tag value on the homepage Canonical URL

## Deployment and testing

### Local Setup

`lando si`

### QA/Testing instructions

- View source or DOM on **homepage**
- Search for "canonical"
- It should should be the site root as an absolute path. 
![image](https://github.com/user-attachments/assets/2ad2a5ca-1023-468a-835a-0bff100e6334)

## Checklist for the Developer

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask for help! -->
- [x] A link to the JIRA ticket has been included above.
- [x] No merge conflicts exist with the target branch.
- [x] Automated tests have passed on this PR.
- [x] A reviewer has been designated.
- [x] Deployment and testing steps have been documented above, if applicable.

## Checklist for the Peer Reviewers

- [ ] The file changes are relevant to the task objective.
- [ ] Code is readable and includes appropriate commenting.
- [ ] Code standards and best practices are followed.
- [ ] QA/Test steps were successfully completed, if applicable.
- [ ] Applicable logs are free of errors.

<!--
Before opening this PR, make sure you’ve done whichever of these applies to you:
- Branch is up-to-date and includes latest from `develop`
- Target branch is correct
- You have ran code standards locally before assigning -`./robo.sh validate:all`
- PR is clear in both the reason it was opened and how the reviewer can confirm the work is done
-->
