### PR TITLE
DIGITAL-578: Fix Prose button width

### DIFF
--- a/web/themes/custom/digital_gov/css/new/_content.scss
+++ b/web/themes/custom/digital_gov/css/new/_content.scss
@@ -84,6 +84,11 @@
   table tbody {
     vertical-align: baseline;
   }
+
+  // Remove max-width from a paragraph if the only child it has is a .usa-button. (DIGITAL-578)
+  p:has(> .usa-button:only-child) {
+    max-width: none;
+  }
 }
 
 .usa-prose > *:first-child {


### PR DESCRIPTION
<!-- Delete any detail that does not apply to this PR! -->

## Jira ticket

[DIGITAL-578](https://cm-jira.usa.gov/browse/DIGITAL-578)

## Purpose

- CKEditor automatically wraps an `<a>` element with a `<p>`element
- The hugo site did not have this requirement. There are now `<a>` tags that are within a `<p>` and were not wrapped this way before.
- `<p>` tags have a `max-width` for readability. 

**Result**:  `<a>` that did not have a `max-width` before now inherit one from their container. This is causing the them to line-break earlier.

## Deployment and testing

### Local Setup

`lando fe`

### QA/Testing instructions

Visually compare button to Live
![image](https://github.com/user-attachments/assets/62c79f37-056a-43d6-afa7-ab6840f6d2fa)

- https://digitalgov.lndo.site/resources/making-open-and-machine-readable-the-new-default-for-government-information

This should hold true for similar buttons on other resources pages.
- https://digitalgov.lndo.site/resources/federal-information-security-management-act-of-2002-presentation-to-the-2003-fissea-conference
- https://digitalgov.lndo.site/resources/requirements-for-accepting-externally-issued-identity-credentials
- etc

## Checklist for the Developer

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask for help! -->
- [ ] A link to the JIRA ticket has been included above.
- [ ] No merge conflicts exist with the target branch.
- [ ] Automated tests have passed on this PR.
- [ ] A reviewer has been designated.
- [ ] Deployment and testing steps have been documented above, if applicable.

## Checklist for the Peer Reviewers

- [ ] The file changes are relevant to the task objective.
- [ ] Code is readable and includes appropriate commenting.
- [ ] Code standards and best practices are followed.
- [ ] QA/Test steps were successfully completed, if applicable.
- [ ] Applicable logs are free of errors.

<!--
Before opening this PR, make sure you’ve done whichever of these applies to you:
- Branch is up-to-date and includes latest from `develop`
- Target branch is correct
- You have ran code standards locally before assigning -`./robo.sh validate:all`
- PR is clear in both the reason it was opened and how the reviewer can confirm the work is done
-->
