### PR TITLE
DIGITAL-593: Increase paragraph width within a dg-note

### DIFF
--- a/web/themes/custom/digital_gov/css/new/shortcodes/_note.scss
+++ b/web/themes/custom/digital_gov/css/new/shortcodes/_note.scss
@@ -41,6 +41,10 @@
     font-weight: font-weight("medium");
   }
 
+  p {
+    max-width: measure(6);
+  }
+
   p:last-child {
     margin-bottom: 0;
   }


### PR DESCRIPTION
<!-- Delete any detail that does not apply to this PR! -->

## Jira ticket
[DIGITAL-593](https://cm-jira.usa.gov/browse/DIGITAL-593)

## Purpose

- CKEditor automatically wraps text not within a container with a `<p>` element. 
- `.dg-note` did not always use a `<p>` within them in the past.
- `<p>` tags have a max-width for readability.

**Result**: Text that did not have a max-width before now inherit one from their container. This is causing the them to line-break earlier. We followed the guidelines on USWDS and increased the width of paragraphs within a `.dg-note` 

## Deployment and testing

### Local Setup

`lando fe`

### QA/Testing instructions
 
- Navigate to https://digitalgov.lndo.site/communities/community-guidelines
- Edit the DOM and remove the Dos and Don't table from lower down on the page (Another bug should not interfere with testing this one - [DIGITAL-626](https://cm-jira.usa.gov/browse/DIGITAL-626))
- Visually compare to Live Site

## Checklist for the Developer

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask for help! -->
- [x] A link to the JIRA ticket has been included above.
- [x] No merge conflicts exist with the target branch.
- [x] Automated tests have passed on this PR.
- [x] A reviewer has been designated.
- [x] Deployment and testing steps have been documented above, if applicable.

## Checklist for the Peer Reviewers

- [ ] The file changes are relevant to the task objective.
- [ ] Code is readable and includes appropriate commenting.
- [ ] Code standards and best practices are followed.
- [ ] QA/Test steps were successfully completed, if applicable.
- [ ] Applicable logs are free of errors.

<!--
Before opening this PR, make sure you’ve done whichever of these applies to you:
- Branch is up-to-date and includes latest from `develop`
- Target branch is correct
- You have ran code standards locally before assigning -`./robo.sh validate:all`
- PR is clear in both the reason it was opened and how the reviewer can confirm the work is done
-->
