### PR TITLE
DIGITAL-642: Fix broken accordions when there are multiples

### DIFF
--- a/web/modules/custom/ec_shortcodes/src/Plugin/EmbeddedContent/ECShortcodesAccordion.php
+++ b/web/modules/custom/ec_shortcodes/src/Plugin/EmbeddedContent/ECShortcodesAccordion.php
@@ -58,7 +58,7 @@ class ECShortcodesAccordion extends EmbeddedContentPluginBase implements Embedde
     $form['accordion_title'] = [
       '#type' => 'text_format',
       '#title' => $this->t('Title'),
-      '#default_value' => $this->configuration['accordion_title'],
+      '#default_value' => $this->configuration['accordion_title']['value'] ?? '',
       '#format' => 'single_inline_html',
       '#allowed_formats' => ['single_inline_html'],
       '#required' => TRUE,

--- a/web/modules/custom/ec_shortcodes/templates/ec-shortcodes-accordion.html.twig
+++ b/web/modules/custom/ec_shortcodes/templates/ec-shortcodes-accordion.html.twig
@@ -1,3 +1,5 @@
+{% set count_prefix = accordion_title.value|striptags|slice(0, 10)|clean_class %}
+{% set count = count_prefix ~ '-' ~ ((count ?? 0) + random()) %}
 <div class="usa-accordion accordion">
   <h3 class="usa-accordion__heading">
     <button class="usa-accordion__button" title="View {{ accordion_title.value|striptags }}" aria-expanded="false" aria-controls="accordion-{{ count }}">

--- a/web/modules/custom/ec_shortcodes/templates/ec-shortcodes-card-policy.html.twig
+++ b/web/modules/custom/ec_shortcodes/templates/ec-shortcodes-card-policy.html.twig
@@ -1,8 +1,8 @@
+{% set count_prefix = card_title.value|striptags|slice(0, 10)|clean_class %}
+{% set count = count_prefix ~ '-' ~ ((count ?? 0) + random()) %}
 <div class="usa-accordion accordion card-policy">
-{% set count = (count ?? 0) + 1 %}
-
   <h3 class="usa-accordion__heading">
-    <button class="usa-accordion__button" title="View {{ title }}" aria-expanded="false" aria-controls="accordion-{{ count }}">
+    <button class="usa-accordion__button" title="View {{ card_title.value|striptags }}" aria-expanded="false" aria-controls="card-policy-{{ count }}">
 
       <span class="scroll">
         <svg class="usa-icon dg-icon dg-icon--large margin-bottom-05" aria-hidden="true" focusable="false">
@@ -27,7 +27,7 @@
   </h3>
 
   {% if text %}
-    <div id="accordion-{{ count }}" class="card-policy-body usa-accordion__content usa-prose">
+    <div id="card-policy-{{ count }}" class="card-policy-body usa-accordion__content usa-prose">
       {% set text = {
         '#type': 'processed_text',
         '#text': text.value,


### PR DESCRIPTION
## Jira ticket

[DIGITAL-642](https://cm-jira.usa.gov/browse/DIGITAL-642)

## Purpose

Accordions and Policy cards (restyled accordions) are not opening correctly if there are more than one on the page.

## Deployment and testing

### Local Setup

`lando drush cr` should do it

### QA/Testing instructions

**Test 1**
Add more than one accordion to the same page
When the accordion is clicked, it should only effect itself

**Test 2**
Test if you can edit the accordion. (this was broken when testing the other, fixed this too)

**Test 3**
Add more than one Policy Card to the same page
When the Policy Card is clicked, it should only effect itself
url of live content - https://digitalgov.lndo.site/resources/required-web-content-and-links


## Checklist for the Developer

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask for help! -->
- [x] A link to the JIRA ticket has been included above.
- [x] No merge conflicts exist with the target branch.
- [x] Automated tests have passed on this PR.
- [x] A reviewer has been designated.
- [x] Deployment and testing steps have been documented above, if applicable.

## Checklist for the Peer Reviewers

- [ ] The file changes are relevant to the task objective.
- [ ] Code is readable and includes appropriate commenting.
- [ ] Code standards and best practices are followed.
- [ ] QA/Test steps were successfully completed, if applicable.
- [ ] Applicable logs are free of errors.

<!--
Before opening this PR, make sure you’ve done whichever of these applies to you:
- Branch is up-to-date and includes latest from `develop`
- Target branch is correct
- You have ran code standards locally before assigning -`./robo.sh validate:all`
- PR is clear in both the reason it was opened and how the reviewer can confirm the work is done
-->
