### PR TITLE
DIGITAL-542: Add URL Alias permission to content workflow users

### DIFF
--- a/config/sync/user.role.author.yml
+++ b/config/sync/user.role.author.yml
@@ -24,6 +24,7 @@ dependencies:
     - node
     - override_node_options
     - paragraphs_type_permissions
+    - path
 id: author
 label: Author
 weight: 3
@@ -46,6 +47,7 @@ permissions:
   - 'create short_post content'
   - 'create source content'
   - 'create topics content'
+  - 'create url aliases'
   - 'edit own authors content'
   - 'edit own basic_page content'
   - 'edit own community content'

--- a/config/sync/user.role.content_admin.yml
+++ b/config/sync/user.role.content_admin.yml
@@ -27,6 +27,7 @@ dependencies:
     - node
     - override_node_options
     - paragraphs_type_permissions
+    - path
     - scheduler
     - sitewide_alert
 id: content_admin
@@ -60,6 +61,7 @@ permissions:
   - 'create short_post content'
   - 'create source content'
   - 'create topics content'
+  - 'create url aliases'
   - 'delete any guide_navigation content'
   - 'delete any media'
   - 'delete sitewide alert entities'

--- a/config/sync/user.role.editor.yml
+++ b/config/sync/user.role.editor.yml
@@ -24,6 +24,7 @@ dependencies:
     - node
     - override_node_options
     - paragraphs_type_permissions
+    - path
 id: editor
 label: Editor
 weight: 4
@@ -34,6 +35,7 @@ permissions:
   - 'access media overview'
   - 'bypass paragraphs type content access'
   - 'create media'
+  - 'create url aliases'
   - 'edit any authors content'
   - 'edit any basic_page content'
   - 'edit any community content'

--- a/config/sync/user.role.publisher.yml
+++ b/config/sync/user.role.publisher.yml
@@ -24,6 +24,7 @@ dependencies:
     - node
     - override_node_options
     - paragraphs_type_permissions
+    - path
     - scheduler
 id: publisher
 label: Publisher
@@ -35,6 +36,7 @@ permissions:
   - 'access media overview'
   - 'bypass paragraphs type content access'
   - 'create media'
+  - 'create url aliases'
   - 'delete any media'
   - 'edit any authors content'
   - 'edit any basic_page content'


### PR DESCRIPTION
<!-- Delete any detail that does not apply to this PR! -->

## Jira ticket

[DIGITAL-542](https://cm-jira.usa.gov/browse/DIGITAL-542)

## Purpose

Give user ability to set the URL path on their content creations within the workflow

## Deployment and testing

### Local Setup

`lando si`

### QA/Testing instructions

Login as each of the following: Author, Editor, Publisher, Content Admin
Edit content and looks to see if user can update the path
![image](https://github.com/user-attachments/assets/93ffe63d-b5ba-4e9a-a9c6-1a8b635673c1)

Remember some content roles can only edit content in a certain state, this is most important with the Editor role. It can only interact with content in the "Ready for Review" State.


## Checklist for the Developer

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask for help! -->
- [x] A link to the JIRA ticket has been included above.
- [x] No merge conflicts exist with the target branch.
- [x] Automated tests have passed on this PR.
- [x] A reviewer has been designated.
- [x] Deployment and testing steps have been documented above, if applicable.

## Checklist for the Peer Reviewers

- [ ] The file changes are relevant to the task objective.
- [ ] Code is readable and includes appropriate commenting.
- [ ] Code standards and best practices are followed.
- [ ] QA/Test steps were successfully completed, if applicable.
- [ ] Applicable logs are free of errors.

<!--
Before opening this PR, make sure you’ve done whichever of these applies to you:
- Branch is up-to-date and includes latest from `develop`
- Target branch is correct
- You have ran code standards locally before assigning -`./robo.sh validate:all`
- PR is clear in both the reason it was opened and how the reviewer can confirm the work is done
-->
