### PR TITLE
DIGITAL-571: Subnav current

### DIFF
--- a/web/modules/custom/dg_guide_nav/dg_guide_nav.module
+++ b/web/modules/custom/dg_guide_nav/dg_guide_nav.module
@@ -87,15 +87,22 @@ function dg_guide_nav_get_links(Node $guideNav, string $current, Node $currentPa
               return $subItem->getUrl()->toString() === $current;
             });
             if ($current_in_subnav) {
-              // We haven't added our item to the guidenav, add 1 to the index.
+              // We haven't added our item to the guidenav, add 1 to the last
+              // index to account for this.
               $links['guide_current_index'] = $links['guide_nav'] ? array_key_last($links['guide_nav']) + 1 : 0;
+
+              // We needed to add one more to the index because twig's loops
+              // start at 1 not 0.
+              $links['guide_menubar_current'] = $links['guide_current_index'] + 1;
             }
           }
         }
         $links['guide_nav'][] = $item;
         if ($item['link']->getUrl()->toString() === $current) {
-          // Mark which top-level page is open.
+          // Set which subnav to display.
           $links['guide_current_index'] = array_key_last($links['guide_nav']);
+          // Mark which top-level page is open. Twig's loops start at 1.
+          $links['guide_menubar_current'] = array_key_last($links['guide_nav']) + 1;
         }
       }
     }

--- a/web/themes/custom/digital_gov/templates/partials/guides/guide-menu-bar.html.twig
+++ b/web/themes/custom/digital_gov/templates/partials/guides/guide-menu-bar.html.twig
@@ -2,9 +2,12 @@
 
 Generates a horizontal menu for desktop and a vertical menu for mobile on all guide pages.
 Displays an optional glossary sidemenu on the right side if glossary is selected for this node.
+dg_guide_nav_get_links() prepares the variables used here.
 
   Requires a variable "guide_nav". See digital_gov_get_guidenav_links() in theme preprocess node function.
   Requires a "node" variable that is the current guide page being viewed.
+  Requires a variable "guide_menubar_current". Sets which of the parent menubar items is marked as current..
+
 #}
 
 {% if guide_nav %}
@@ -40,7 +43,8 @@ Displays an optional glossary sidemenu on the right side if glossary is selected
       </div>
       <nav class="dg-guide__menu-bar-links" aria-label="Secondary menu bar">
         {% for item in guide_nav %}
-          {{ _self.link_item(item.link, path('<current>')) }}
+          {% set isCurrent = loop.index == guide_menubar_current %}
+          {{ _self.link_item(item.link, isCurrent) }}
         {% endfor %}
       </nav>
     </div>
@@ -101,16 +105,17 @@ Displays an optional glossary sidemenu on the right side if glossary is selected
     >
       <nav class="guide-mobile-menu__nav" aria-label="Secondary menu bar">
         {% for item in guide_nav %}
-          {{ _self.link_item(item.link, path('<current>')) }}
+          {% set isCurrent = loop.index == guide_menubar_current %}
+          {{ _self.link_item(item.link, isCurrent) }}
         {% endfor %}
       </nav>
     </div>
   </div>
 {% endif %}
 
-{% macro link_item(link, current) %}
+{% macro link_item(link, isCurrent) %}
   <a
-    class="dg-guide__menu-bar-link {{ current == link.url.toString() ? 'dg-current' : '' }}"
+    class="dg-guide__menu-bar-link {{ isCurrent ? 'dg-current' : '' }}"
     href="{{ link.url }}#content-start"
     title="{{ link.text }}"
   >{{ link.text }}</a


### PR DESCRIPTION
Fixes setting which menubar item to highlight as current when viewing a page in the subnav.

<!-- Delete any detail that does not apply to this PR! -->

## Jira ticket

<!-- Insert a link to the Jira ticket (e.g DIGITAL-XXX). -->
<!-- Update the example below with number and paste url to ticket in the () -->
<!-- Should match the following [DIGITAL-xxx](www.pathtoticket.com) -->
[DIGITAL-571](https://cm-jira.usa.gov/browse/DIGITAL-571)

## Purpose
Fixes setting which menubar item to highlight as current when viewing a page in the subnav.
<!--Insert a brief summary of the changes included in this PR and any additional information or context which may help the reviewer.

It can be helpful to understand:
1. What the solution is,
2. Why this approach was chosen,
3. How you implemented the change
4. Possible limitations of this approach and alternate solution paths. -->

## Includes the following PRs that must be merged first

<!-- Optional: List any PRs that must be merged before this one can be reviewed. -->

## Deployment and testing

### Local Setup
`lando si`

<!--Insert any required steps to take before beginning to test. Such as `lando rebuild`, rebuilding frontend or config updates needed to follow the testing steps.-->

### QA/Testing instructions

1. Visit https://digitalgov.lndo.site/guides/desk-research#content-start (a subpage of page in the guide nav)
2. At desktop width, You should see "Framing" marked as current with the blue underline in the guide menubar.
3. On mobile width, you should see "framing" marked as current with blue text in the mobile hamburger guide navigation.
4. Navigationg the top-level guide pages should be unchanged (i.e., the page is highlighted and its subnav is shown on left)
Like this but I have migrated content, not the default content:

![image](https://github.com/user-attachments/assets/ecefcec8-e101-409d-8ba7-2d73b58c5221)

![image](https://github.com/user-attachments/assets/48139771-2aca-4646-8443-58e046a72eb6)


<!--Insert steps to test and confirm the result meets the "definition of done".-->

## Checklist for the Developer

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask for help! -->
- [x] A link to the JIRA ticket has been included above.
- [x] No merge conflicts exist with the target branch.
- [x] Automated tests have passed on this PR.
- [x] A reviewer has been designated.
- [ ] Deployment and testing steps have been documented above, if applicable.

## Checklist for the Peer Reviewers

- [ ] The file changes are relevant to the task objective.
- [ ] Code is readable and includes appropriate commenting.
- [ ] Code standards and best practices are followed.
- [ ] QA/Test steps were successfully completed, if applicable.
- [ ] Applicable logs are free of errors.

<!--
Before opening this PR, make sure you’ve done whichever of these applies to you:
- Branch is up-to-date and includes latest from `develop`
- Target branch is correct
- You have ran code standards locally before assigning -`./robo.sh validate:all`
- PR is clear in both the reason it was opened and how the reviewer can confirm the work is done
-->
