### PR TITLE
DIGITAL-651: Fix for images not appearing on search.gov

### DIFF
--- a/scripts/upkeep
+++ b/scripts/upkeep
@@ -71,11 +71,14 @@ echo "Performing find and replace tasks..."
 echo "**************************************************"
 echo "-- Replace s3-based file urls with relative urls"
 echo "**************************************************"
-find "${html_path}" -type f -exec grep -l 'http[s]*://[^/]\+/s3/files' {} \; -exec sed -i 's#http[s]*://[^/]\+/s3/files#/s3/files#g' {} +
+
+## Fix for DIGITAL-651
+find "${html_path}" -type f -exec grep -l 'http[s]*://[^/]\+/s3/files' -v 'meta property="op:image"' -v 'meta name="twitter:image"' {} \; -exec sed -i 's#http[s]*://[^/]\+/s3/files#/s3/files#g' {} +
+find "${html_path}" -type f -exec grep -l 'http[s]*://[^/]\+/s3/files' {} \; -exec sed -i "s#${DRUSH_OPTIONS_URI}/s3/files#${STATIC_URI}/s3/files#g" {} +
 echo "**************************************************"
 echo "-- Replace absolute urls with relative urls in generated files"
 echo "**************************************************"
-find "${html_path}/sites/default/files" -type f -exec grep -l "${STATIC_URI}/" {} \; -exec sed -i "s#${STATIC_URI}/#/#g" {} +
+find "${html_path}/sites/default/files" -type f -exec grep -l "${STATIC_URI}/" -v 'meta property="op:image"' -v 'meta name="twitter:image"' {} \; -exec sed -i "s#${STATIC_URI}/#/#g" {} +
 echo "Performing find and replace tasks...completed!"
 echo ""
 echo "**************************************************"


### PR DESCRIPTION
<!-- Delete any detail that does not apply to this PR! -->

## Jira ticket

<!-- Insert a link to the Jira ticket (e.g DIGITAL-XXX). -->
<!-- Update the example below with number and paste url to ticket in the () -->
<!-- Should match the following [DIGITAL-xxx](www.pathtoticket.com) -->
[DIGITAL-651](https://cm-jira.usa.gov/browse/DIGITAL-651)

## Purpose

Fix upkeep script for images URL not appearing on search.gov.