### PR TITLE
DIGITAL-571: Guidenav reset subs

### DIFF
--- a/web/modules/custom/dg_guide_nav/dg_guide_nav.module
+++ b/web/modules/custom/dg_guide_nav/dg_guide_nav.module
@@ -78,6 +78,7 @@ function dg_guide_nav_get_links(Node $guideNav, string $current, Node $currentPa
         $count++;
 
         if ($para->field_guide_subnav) {
+          $item['subnav'] = [];
           $subNavNodes = $para->get('field_guide_subnav')->referencedEntities();
           $subNavNodes = array_filter($subNavNodes, fn(Node $node) => $guideNav->isPublished());
           if ($subNavNodes) {


### PR DESCRIPTION
<!-- Delete any detail that does not apply to this PR! -->

## Jira ticket

<!-- Insert a link to the Jira ticket (e.g DIGITAL-XXX). -->
<!-- Update the example below with number and paste url to ticket in the () -->
<!-- Should match the following [DIGITAL-xxx](www.pathtoticket.com) -->
[DIGITAL-571](https://cm-jira.usa.gov/browse/DIGITAL-571)

## Purpose
 Need to reset the subnav links for each item to prevent …a previous subnav's links from showing up in an adjacent subnav when the sibling doesn't have a subnav.
<!--Insert a brief summary of the changes included in this PR and any additional information or context which may help the reviewer.

It can be helpful to understand:
1. What the solution is,
2. Why this approach was chosen,
3. How you implemented the change
4. Possible limitations of this approach and alternate solution paths. -->

## Includes the following PRs that must be merged first

<!-- Optional: List any PRs that must be merged before this one can be reviewed. -->

## Deployment and testing

### Local Setup
Not sure how to set this up on local, the default content isn't configured with this scenario. Migrated content requires manual set up of the guide navs as they are on prod.

<!--Insert any required steps to take before beginning to test. Such as `lando rebuild`, rebuilding frontend or config updates needed to follow the testing steps.-->

### QA/Testing instructions
Currently on prod, the bug is on some guide navs. If a page doesn't have a subnav, the previous subnav is re-used.

Case <https://digital-gov-drupal-prod.app.cloud.gov/guides/hcd/discovery-concepts/find-opportunities#content-start> The "Discover" page doesn't have any sub nav pages, but the "Goals and Insights" link is showing because it's a link in the previous page.

![image](https://github.com/user-attachments/assets/9db03909-957b-4929-bd4e-4d1057f5b29c)

With this fix, that same set up on my local does not show the "Goals and Insights" page

![image](https://github.com/user-attachments/assets/7d86ed2a-0ae9-4c79-880f-3428b161dd1b)

<!--Insert steps to test and confirm the result meets the "definition of done".-->

## Checklist for the Developer

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask for help! -->
- [x] A link to the JIRA ticket has been included above.
- [x] No merge conflicts exist with the target branch.
- [x] Automated tests have passed on this PR.
- [x] A reviewer has been designated.
- [ ] Deployment and testing steps have been documented above, if applicable.

## Checklist for the Peer Reviewers

- [ ] The file changes are relevant to the task objective.
- [ ] Code is readable and includes appropriate commenting.
- [ ] Code standards and best practices are followed.
- [ ] QA/Test steps were successfully completed, if applicable.
- [ ] Applicable logs are free of errors.

<!--
Before opening this PR, make sure you’ve done whichever of these applies to you:
- Branch is up-to-date and includes latest from `develop`
- Target branch is correct
- You have ran code standards locally before assigning -`./robo.sh validate:all`
- PR is clear in both the reason it was opened and how the reviewer can confirm the work is done
-->
