### PR TITLE
DIGITAL-593: Remove extra wrapper breaking prose styles

### DIFF
--- a/web/themes/custom/digital_gov/templates/node/node--community.html.twig
+++ b/web/themes/custom/digital_gov/templates/node/node--community.html.twig
@@ -110,9 +110,7 @@
               </div>
             </section>
           {% endif %}
-          <div class="content">
-            {{ content.body|field_value }}
-          </div>
+          {{ content.body|field_value }}
 
           {# TODO future community events not sure how this needs to be set up - ticket  DIGITAL-293 #}
           {# [placeholder Upcoming events] #}


### PR DESCRIPTION
## Jira ticket

[DIGITAL-593](https://cm-jira.usa.gov/browse/DIGITAL-593)

## Purpose

Community node pages have an extra div wrapping the content. This breaks the `.usa-prose` styles because that class expects a direct child to accept the styles.

## Deployment and testing

### Local Setup

`lando fe`

### QA/Testing instructions

View a comunity page
1. Search the DOM for `.content`
2. There should only be one class that matches that

## Checklist for the Developer

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask for help! -->
- [x] A link to the JIRA ticket has been included above.
- [x] No merge conflicts exist with the target branch.
- [x] Automated tests have passed on this PR.
- [x] A reviewer has been designated.
- [x] Deployment and testing steps have been documented above, if applicable.

## Checklist for the Peer Reviewers

- [ ] The file changes are relevant to the task objective.
- [ ] Code is readable and includes appropriate commenting.
- [ ] Code standards and best practices are followed.
- [ ] QA/Test steps were successfully completed, if applicable.
- [ ] Applicable logs are free of errors.

<!--
Before opening this PR, make sure you’ve done whichever of these applies to you:
- Branch is up-to-date and includes latest from `develop`
- Target branch is correct
- You have ran code standards locally before assigning -`./robo.sh validate:all`
- PR is clear in both the reason it was opened and how the reviewer can confirm the work is done
-->
