### PR TITLE
DIGITAL-657: Fix featured resources autocomplete bundle definition 

### DIFF
--- a/web/modules/custom/ec_shortcodes/src/Plugin/EmbeddedContent/ECShortcodesFeaturedResource.php
+++ b/web/modules/custom/ec_shortcodes/src/Plugin/EmbeddedContent/ECShortcodesFeaturedResource.php
@@ -103,7 +103,7 @@ final class ECShortcodesFeaturedResource extends EmbeddedContentPluginBase imple
       '#required' => TRUE,
       '#selection_settings' => [
         'target_bundles' => [
-          'authors', 'basic_page', 'community', 'event', 'guide',
+          'authors', 'basic_page', 'community', 'event', 'guides',
           'news', 'resources', 'services', 'topics',
         ],
       ],

--- a/web/modules/custom/ec_shortcodes/src/Plugin/EmbeddedContent/ECShortcodesFeaturedResource.php
+++ b/web/modules/custom/ec_shortcodes/src/Plugin/EmbeddedContent/ECShortcodesFeaturedResource.php
@@ -103,8 +103,8 @@ final class ECShortcodesFeaturedResource extends EmbeddedContentPluginBase imple
       '#required' => TRUE,
       '#selection_settings' => [
         'target_bundles' => [
-          'authors', 'basic_page', 'community', 'event', 'guides',
-          'news', 'resources', 'services', 'topics',
+          'authors', 'basic_page', 'community', 'event', 'guide_landing',
+          'guides', 'landing_page', 'news', 'resources', 'topics',
         ],
       ],
     ];


### PR DESCRIPTION
<!-- Delete any detail that does not apply to this PR! -->

## Jira ticket

[DIGITAL-657](https://cm-jira.usa.gov/browse/DIGITAL-657)

## Purpose

Guides could not be added as Featured Resource because the machine name was misspelled in the autocomplete. Where it had been added by a migration, it could not be updated because it broke the reference.


## Deployment and testing

### Local Setup

`lando drush cr`

### QA/Testing instructions

Add a Featured resource embedded content that is a guide to a WYSIWYG.
save the node and try to edit it.

If you have migrated content locally then you can try and update the following node's Featured Resources.
/guides/hcd/introduction/approach

## Checklist for the Developer

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask for help! -->
- [x] A link to the JIRA ticket has been included above.
- [x] No merge conflicts exist with the target branch.
- [x] Automated tests have passed on this PR.
- [x] A reviewer has been designated.
- [x] Deployment and testing steps have been documented above, if applicable.

## Checklist for the Peer Reviewers

- [ ] The file changes are relevant to the task objective.
- [ ] Code is readable and includes appropriate commenting.
- [ ] Code standards and best practices are followed.
- [ ] QA/Test steps were successfully completed, if applicable.
- [ ] Applicable logs are free of errors.

<!--
Before opening this PR, make sure you’ve done whichever of these applies to you:
- Branch is up-to-date and includes latest from `develop`
- Target branch is correct
- You have ran code standards locally before assigning -`./robo.sh validate:all`
- PR is clear in both the reason it was opened and how the reviewer can confirm the work is done
-->
