### PR TITLE
DIGITAL-323: Secure CMS behind corporate proxy.

### DIFF
--- a/terraform/applications/nginx-waf/nginx/snippets/ip-restrict-cms.conf.tmpl
+++ b/terraform/applications/nginx-waf/nginx/snippets/ip-restrict-cms.conf.tmpl
@@ -1,6 +1,7 @@
 #allow 127.0.0.1/32;
 #allow 172.0.0.0/8;
 
-${IPS_ALLOWED_CMS}
 
-#deny all;
+deny all;
+
+${IPS_ALLOWED_CMS}

--- a/terraform/infra/locals.tf
+++ b/terraform/infra/locals.tf
@@ -52,9 +52,9 @@ locals {
 
           ## IP addresses allowed to connected to the CMS.
           ALLOWED_IPS_CMS = base64encode(
-            jsonencode([
-              "allow 0.0.0.0/0;"
-              #"allow 159.142.0.0/16;"
+             jsonencode([
+              "allow 159.142.0.0/16;",
+              "location = /update.php { allow 159.142.0.0/16; proxy_pass ${local.cms_fqdn}; }",
             ])
           )
 


### PR DESCRIPTION
## Jira ticket

[DIGITAL-323](https://cm-jira.usa.gov/browse/DIGITAL-323)

## Purpose

Restricts CMS access to the GSA address pool.