### PR TITLE
DIGITAL-000: Add redirects for search.gov

### DIFF
--- a/terraform/applications/nginx-waf/nginx/conf.d/default.conf
+++ b/terraform/applications/nginx-waf/nginx/conf.d/default.conf
@@ -21,7 +21,17 @@ server {
 
     set $cf_forwarded_host "$host";
 
-    set $port 8881;    
+    ## Redirect these hostnames to digital.gov/guides/search
+    if ($cf_forwarded_host ~* ^(www\.)?search\.gov$) {
+      return 301 https://digital.gov/guides/search;
+    }
+
+    ## Temporary TEST configuration for above redirects with a throw-away subdomain
+    if ($cf_forwarded_host ~* ^(whtnfrvemzeq\.)?search\.gov$) {
+      return 301 https://digital.gov/guides/search;
+    }
+
+    set $port 8881;
 
     if ($cf_forwarded_host ~* \-drupal\-|^cms\.) {
       set $port 8882;


### PR DESCRIPTION
<!-- Delete any detail that does not apply to this PR! -->

## Purpose

<!--Insert a brief summary of the changes included in this PR and any additional information or context which may help the reviewer.

It can be helpful to understand:
1. What the solution is,
2. Why this approach was chosen,
3. How you implemented the change
4. Possible limitations of this approach and alternate solution paths. -->

Adds two stanzas to nginx conf for the waf. The first redirects all requests the hosts `search.gov` and `www.search.gov` to the path for the search guide on `digital.gov`. 

The second does the same, but for a search subdomain that doesn't exist yet. I would like to test the rest of the setup (cloud.gov routes, domain service, etc) before switching the domains over and I believe I can set up this temporary subdomain to do that. We should remove this after we complete the switchover. 


## Checklist for the Developer

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask for help! -->
- [ ] A link to the JIRA ticket has been included above.
- [x] No merge conflicts exist with the target branch.
- [ ] Automated tests have passed on this PR.
- [x] A reviewer has been designated.
- [ ] Deployment and testing steps have been documented above, if applicable.

## Checklist for the Peer Reviewers

- [ ] The file changes are relevant to the task objective.
- [ ] Code is readable and includes appropriate commenting.
- [ ] Code standards and best practices are followed.
- [ ] QA/Test steps were successfully completed, if applicable.
- [ ] Applicable logs are free of errors.

<!--
Before opening this PR, make sure you’ve done whichever of these applies to you:
- Branch is up-to-date and includes latest from `develop`
- Target branch is correct
- You have ran code standards locally before assigning -`./robo.sh validate:all`
- PR is clear in both the reason it was opened and how the reviewer can confirm the work is done
-->
