### PR TITLE
DIGITAL-736: Improve selection of headings in summary-box.js

### DIFF
--- a/web/themes/custom/digital_gov/js/summary-box.js
+++ b/web/themes/custom/digital_gov/js/summary-box.js
@@ -13,11 +13,14 @@
 
   const guideSummaryList = guideSummary.querySelector(".usa-list");
   /**
-   * Return a list of h2's to display in the summary box
-   * and filter out h2's we do not want to show with the :not selector
+   * Return a list of h2's to display in the summary box. We want h2s:
+   *  - from the body of the page only (div.dg-guide__content_body)
+   *  - not the summary box heading (.usa-summary-box__heading)
+   *  - not a few other things (note .visually-hidden is not reliable)
+   * We will also skip h2s without IDs in the createSummaryBox loop.
    */
   const pageHeaders = document.querySelectorAll(
-    "h2:not(.usa-summary-box__heading, .dg-guide__content-header-title, .dg-glossary__header, .visually-hidden)"
+    "div.dg-guide__content-body > h2:not(.usa-summary-box__heading, .dg-guide__content-header-title, .dg-glossary__header, .visually-hidden)"
   );
 
   /**
@@ -26,16 +29,18 @@
   function createSummaryBox() {
     const summaryBoxFragment = document.createDocumentFragment();
     pageHeaders.forEach((link) => {
-      const summaryListItem = document.createElement("li");
+      if (link.id) { // skip, not a link.
+          const summaryListItem = document.createElement("li");
 
-      const summaryLink = Object.assign(document.createElement("a"), {
-        class: "usa-summary-box__link",
-        href: `#${link.id}`,
-        innerHTML: `${link.innerText}`,
-      });
+          const summaryLink = Object.assign(document.createElement("a"), {
+              class: "usa-summary-box__link",
+              href: `#${link.id}`,
+              innerHTML: `${link.innerText}`,
+          });
 
-      summaryListItem.appendChild(summaryLink);
-      summaryBoxFragment.appendChild(summaryListItem);
+          summaryListItem.appendChild(summaryLink);
+          summaryBoxFragment.appendChild(summaryListItem);
+      }
     });
 
     guideSummaryList.appendChild(summaryBoxFragment);


### PR DESCRIPTION
<!-- Delete any detail that does not apply to this PR! -->

## Jira ticket

<!-- Insert a link to the Jira ticket (e.g DIGITAL-XXX). -->
<!-- Update the example below with number and paste url to ticket in the () -->
<!-- Should match the following [DIGITAL-xxx](www.pathtoticket.com) -->
[DIGITAL-736](https://gsa-standard.atlassian-us-gov-mod.net/browse/DIGITAL-736)

## Purpose

Improve the way summary-box.js finds headings to include in the summary box of a Guide. (This box appears on a Guide page when the "summary box" field is checked, and is headed "On this page")

The current code excludes elements with the `.visually-hidden` class, but this turns out to be unreliable. In particular, if you have a guide with multiple tabs, the hidden "Success" and "Error" headings will start appearing in the summary box if you tab back and forth a bit. 

This change selects only headings within the body of the guide (`div.dg-guide__content-body`), which eliminates any H2s in the footer of the guide. It also skips any H2s that lack IDs -- since it's using the ID to make a link, these wouldn't work anyway, and lack of an ID happens to be a property of the headings I want to exclude as well.

## Deployment and testing

### Local Setup

Run `lando fe` to regenerate the webpack js.

### QA/Testing instructions

<!--Insert steps to test and confirm the result meets the "definition of done".-->
1. Find or create a node of content type "Guide" with some H2 headings in the body field, and with `summary box` checked. HINT: if you have default content, the Site Scanning guide has several headings; you just need to edit it and check the box. 
2. View the guide and verify that the headings under "On this page" are correct. 

## Checklist for the Developer

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask for help! -->
- [x] A link to the JIRA ticket has been included above.
- [x] No merge conflicts exist with the target branch.
- [x] Automated tests have passed on this PR.
- [x] A reviewer has been designated.
- [x] Deployment and testing steps have been documented above, if applicable.

## Checklist for the Peer Reviewers

- [x] The file changes are relevant to the task objective.
- [x] Code is readable and includes appropriate commenting.
- [x] Code standards and best practices are followed.
- [ ] QA/Test steps were successfully completed, if applicable.
- [ ] Applicable logs are free of errors.

<!--
Before opening this PR, make sure you’ve done whichever of these applies to you:
- Branch is up-to-date and includes latest from `develop`
- Target branch is correct
- You have ran code standards locally before assigning -`./robo.sh validate:all`
- PR is clear in both the reason it was opened and how the reviewer can confirm the work is done
-->


[DIGITAL-736]: https://gsa-standard.atlassian-us-gov-mod.net/browse/DIGITAL-736