### PR TITLE
DIGITAL-748: Add redirects for public-sans and designsystem

### DIFF
--- a/terraform/applications/nginx-waf/nginx/conf.d/default.conf
+++ b/terraform/applications/nginx-waf/nginx/conf.d/default.conf
@@ -26,15 +26,19 @@ server {
       return 301 https://digital.gov/guides/search;
     }
 
-    ## Temporary TEST configuration for above redirects with a throw-away subdomain
-    if ($cf_forwarded_host ~* ^(whtnfrvemzeq\.)?search\.gov$) {
-      return 301 https://digital.gov/guides/search;
-    }
-
     ## Redirect portal.challenge.gov to challenge.gov - DIGITAL-738
     if ($cf_forwarded_host ~* ^portal\.challenge\.gov$) {
       return 301 https://challenge.gov;
     }
+
+    ## Redirect public-sans and v1.designsystem - DIGITAL-748
+    if ($cf_forwarded_host ~* ^public-sans\.digital\.gov$) {
+      return 301 https://digital.gov/resources/an-introduction-to-typography;
+    }
+    if ($cf_forwarded_host ~* ^v1\.designsystem\.digital\.gov$) {
+      return 301 https://designsystem.digital.gov;
+    }
+
 
     set $port 8881;
 


### PR DESCRIPTION
<!-- Delete any detail that does not apply to this PR! -->

## Jira ticket

<!-- Insert a link to the Jira ticket (e.g DIGITAL-XXX). -->
<!-- Update the example below with number and paste url to ticket in the () -->
<!-- Should match the following [DIGITAL-xxx](www.pathtoticket.com) -->
[DIGITAL-748](https://gsa-standard.atlassian-us-gov-mod.net/browse/DIGITAL-748)

## Purpose

Adds two redirects to the WAF's nginx configuration. 

Incidentally removes a redirect that was only there to test the approach; no longer needed! 

## Deployment and testing

### Local Setup

N/A

### QA/Testing instructions

Inspect for typos. 

## Checklist for the Developer

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask for help! -->
- [ ] A link to the JIRA ticket has been included above.
- [ ] No merge conflicts exist with the target branch.
- [ ] Automated tests have passed on this PR.
- [ ] A reviewer has been designated.
- [ ] Deployment and testing steps have been documented above, if applicable.

## Checklist for the Peer Reviewers

- [ ] The file changes are relevant to the task objective.
- [ ] Code is readable and includes appropriate commenting.
- [ ] Code standards and best practices are followed.
- [ ] QA/Test steps were successfully completed, if applicable.
- [ ] Applicable logs are free of errors.

<!--
Before opening this PR, make sure you’ve done whichever of these applies to you:
- Branch is up-to-date and includes latest from `develop`
- Target branch is correct
- You have ran code standards locally before assigning -`./robo.sh validate:all`
- PR is clear in both the reason it was opened and how the reviewer can confirm the work is done
-->


[DIGITAL-748]: https://gsa-standard.atlassian-us-gov-mod.net/browse/DIGITAL-748