### PR TITLE
DIGITAL-760: Set all in-page-nav components to pick up H2 headings only

### DIFF
--- a/web/themes/custom/digital_gov/templates/node/node--basic-page.html.twig
+++ b/web/themes/custom/digital_gov/templates/node/node--basic-page.html.twig
@@ -85,6 +85,7 @@
         class="usa-in-page-nav"
         data-title-heading-level="h3"
         data-root-margin="-350px 0px -350px 0px"
+        data-heading-elements="h2"
       ></aside>
       {% endif %}
 

--- a/web/themes/custom/digital_gov/templates/node/node--community.html.twig
+++ b/web/themes/custom/digital_gov/templates/node/node--community.html.twig
@@ -86,6 +86,7 @@
         class="usa-in-page-nav"
         data-title-heading-level="h3"
         data-root-margin="-350px 0px -350px 0px"
+        data-heading-elements="h2"
       ></aside>
       <div>
         <div class="content usa-prose">

--- a/web/themes/custom/digital_gov/templates/node/node--guides.html.twig
+++ b/web/themes/custom/digital_gov/templates/node/node--guides.html.twig
@@ -87,7 +87,7 @@
         data-title-text="On this page"
         data-title-heading-level="h2"
         data-main-content-selector=".dg-guide__content"
-        data-heading-elements="h2 h3"
+        data-heading-elements="h2"
         data-root-margin="-100px 0px -55% 0px"
         data-scroll-offset="100"
       ></aside>


### PR DESCRIPTION
<!-- Delete any detail that does not apply to this PR! -->

## Jira ticket

<!-- Insert a link to the Jira ticket (e.g DIGITAL-XXX). -->
<!-- Update the example below with number and paste url to ticket in the () -->
<!-- Should match the following [DIGITAL-xxx](www.pathtoticket.com) -->
[DIGITAL-760](https://gsa-standard.atlassian-us-gov-mod.net/browse/DIGITAL-760)

## Purpose

<!--Insert a brief summary of the changes included in this PR and any additional information or context which may help the reviewer.

It can be helpful to understand:
1. What the solution is,
2. Why this approach was chosen,
3. How you implemented the change
4. Possible limitations of this approach and alternate solution paths. -->

The [USWDS in-page navigation component ](https://designsystem.digital.gov/components/in-page-navigation/)can be configured to include specific heading levels, with the default being to include H2 and H3 headings. We want to include H2s only. (Some of the pages have "too many" H3s.) 

This is an update of each instance of in-page navigation in the theme templates.

## Deployment and testing

### Local Setup

<!--Insert any required steps to take before beginning to test. Such as `lando rebuild`, rebuilding frontend or config updates needed to follow the testing steps.-->

Clear the twig render cache (or all caches). 

You will also need to create or update some content to verify the change works, as described below.

### QA/Testing instructions

<!--Insert steps to test and confirm the result meets the "definition of done".-->
There are four page types that can show in-page nav. You must have a page of each type with H2 and H3 headings, and with in-page nav turned on. 

You want to verify: 
 - In-page nav shows H2s
 - In-page nav shows _only_ H2s. 

Note also that in-page nav will not populate unless there are at least two H2s in the content region of the page. 

If you have a recent copy of the production database loaded, I can suggest specific example pages. 

#### Guides

Suggested page: http://digitalgov.lndo.site/guides/public-participation/understand#content-start

This page has H2s and H3s, and enough H2s to populate in-page nav, but in-page nav is not turned on for this guide. 

You will need to turn "show in-page nav" on. Guides are a little special here, in that the "show in-page nav" setting is on the guide navigation, not the guide page itself. In Edit mode for the page, look for "Guide Navigation," then find the content of type "Guide Navigation" with the same name and edit it. If you have a prod snapshot you can go straight to http://digitalgov.lndo.site/node/3600/edit to edit the navigation for this guide. Check "Show In-page Nav" and save. 

Don't worry about "On this Page" showing up as a linked element in the nav. When (if) they turn this on in prod they'll surely turn off that redundant section. 

#### Community

Suggested page: http://digitalgov.lndo.site/communities/community-guidelines

This is the only page with enough headings to trigger in-page nav, and they're all H2s, so you'll need to edit the content and add an H3 to verify that it is not going to show up in in-page nav. 

In-page nav is automatically enabled for this content type (it just requires multiple H2s), so that's all you need to do to make a test case. 

#### Basic page

Suggested page: http://digitalgov.lndo.site/style-guide

In-page nav is always going to show on a Basic page, provided there are enough H2s. This page has a lot of H3s as well. 

#### Resources

Suggested page: http://digitalgov.lndo.site/resources/introduction-to-federal-web-standards

Nothing has changed here; this content type was already set up the way we want it. 

## Checklist for the Developer

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask for help! -->
- [x] A link to the JIRA ticket has been included above.
- [x] No merge conflicts exist with the target branch.
- [x] Automated tests have passed on this PR.
- [x] A reviewer has been designated.
- [x] Deployment and testing steps have been documented above, if applicable.

## Checklist for the Peer Reviewers

- [ ] The file changes are relevant to the task objective.
- [ ] Code is readable and includes appropriate commenting.
- [ ] Code standards and best practices are followed.
- [ ] QA/Test steps were successfully completed, if applicable.
- [ ] Applicable logs are free of errors.

<!--
Before opening this PR, make sure you’ve done whichever of these applies to you:
- Branch is up-to-date and includes latest from `develop`
- Target branch is correct
- You have ran code standards locally before assigning -`./robo.sh validate:all`
- PR is clear in both the reason it was opened and how the reviewer can confirm the work is done
-->


[DIGITAL-760]: https://gsa-standard.atlassian-us-gov-mod.net/browse/DIGITAL-760