### PR TITLE
DIGITAL-763: Add padding above in-page nav on Guides

### DIFF
--- a/web/themes/custom/digital_gov/css/new/guides/_guide-content.scss
+++ b/web/themes/custom/digital_gov/css/new/guides/_guide-content.scss
@@ -21,6 +21,8 @@
   max-width: none;
   width: 100%;
 
+  // maintains space between menu bar and nav when page is scrolled down:
+  top: 4rem;
 
   @include at-media("tablet") {
     margin-left: units(5);


### PR DESCRIPTION
<!-- Delete any detail that does not apply to this PR! -->

## Jira ticket

<!-- Insert a link to the Jira ticket (e.g DIGITAL-XXX). -->
<!-- Update the example below with number and paste url to ticket in the () -->
<!-- Should match the following [DIGITAL-xxx](www.pathtoticket.com) -->
[DIGITAL-763](https://gsa-standard.atlassian-us-gov-mod.net/browse/DIGITAL-763)

## Purpose

Minor CSS adjustment to add a little more padding to the "top" of in-page nav on Guide pages, so that when the user scrolls down the page, the "On this page" heading of in-page nav doesn't get partially covered by the menu bar. 

## Deployment and testing

### Local Setup

Run `lando fe` to rebuild the css.

### QA/Testing instructions

<!--Insert steps to test and confirm the result meets the "definition of done".-->
Observe the undesired behavior at https://digital-gov-drupal-staging.app.cloud.gov/guides/accessibility-for-teams/content-design : when you scroll down the menu bar will overlap the "On this page" heading of the side nav. 

Compare with a Guide page on local dev. If you just reviewed my last PR, this one's probably set up to show in-page nav: http://digitalgov.lndo.site/guides/public-participation/understand


## Checklist for the Developer

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask for help! -->
- [x] A link to the JIRA ticket has been included above.
- [x] No merge conflicts exist with the target branch.
- [x] Automated tests have passed on this PR.
- [x] A reviewer has been designated.
- [x] Deployment and testing steps have been documented above, if applicable.

## Checklist for the Peer Reviewers

- [ ] The file changes are relevant to the task objective.
- [ ] Code is readable and includes appropriate commenting.
- [ ] Code standards and best practices are followed.
- [ ] QA/Test steps were successfully completed, if applicable.
- [ ] Applicable logs are free of errors.

<!--
Before opening this PR, make sure you’ve done whichever of these applies to you:
- Branch is up-to-date and includes latest from `develop`
- Target branch is correct
- You have ran code standards locally before assigning -`./robo.sh validate:all`
- PR is clear in both the reason it was opened and how the reviewer can confirm the work is done
-->


[DIGITAL-763]: https://gsa-standard.atlassian-us-gov-mod.net/browse/DIGITAL-763