### PR TITLE
DIGITAL-791: Update nginx version to 1.28.3, supported by current buildpack

### DIFF
--- a/scripts/pipeline/cloud-gov-waf-version.sh
+++ b/scripts/pipeline/cloud-gov-waf-version.sh
@@ -11,10 +11,8 @@
 # include updating it in our regular review process.
 
 # NB: Mainline nginx versions are denoted by an even number in the second part of the version number.
-NGINX_VERSION=1.28.1
+NGINX_VERSION=1.28.3
 
 
 export nginx_version=${NGINX_VERSION}
 echo "nginx_version=${NGINX_VERSION}"
-
-

--- a/terraform/applications/nginx-waf/.docker/Dockerfile
+++ b/terraform/applications/nginx-waf/.docker/Dockerfile
@@ -1,5 +1,5 @@
 ARG modsecurity_nginx_version="1.0.3"
-ARG nginx_version="1.25.4"
+ARG nginx_version="1.28.3"
 ARG ubuntu_version="jammy"
 
 FROM docker.io/ubuntu:${ubuntu_version}

--- a/terraform/applications/nginx-waf/.docker/RUNBOOK.md
+++ b/terraform/applications/nginx-waf/.docker/RUNBOOK.md
@@ -14,7 +14,7 @@ The `Dockerfile` initializes a Docker image that is based on the Ubuntu `jammy` 
 1. **ARG Values Declaration**
    ```
    ARG modsecurity_nginx_version="1.0.3"
-   ARG nginx_version="1.25.4"
+   ARG nginx_version="1.28.3"
    ARG ubuntu_version="jammy"
    ```
    These environment variables are important because they allow the builder to specify the exact versions of the components that will be built.

--- a/terraform/applications/nginx-waf/buildpack.yml
+++ b/terraform/applications/nginx-waf/buildpack.yml
@@ -1,3 +1,3 @@
 ---
 nginx:
-  version: 1.28.1
+  version: 1.28.3


### PR DESCRIPTION


<!-- Delete any detail that does not apply to this PR! -->

## Jira ticket

<!-- Insert a link to the Jira ticket (e.g DIGITAL-XXX). -->
<!-- Update the example below with number and paste url to ticket in the () -->
<!-- Should match the following [DIGITAL-xxx](www.pathtoticket.com) -->
[DIGITAL-791](https://gsa-standard.atlassian-us-gov-mod.net/browse/DIGITAL-791)

Discussed at length in Slack. Successful deployment logs here: https://github.com/GSA/digital-gov-drupal/actions/runs/28064144579/job/83086446259



[DIGITAL-791]: https://gsa-standard.atlassian-us-gov-mod.net/browse/DIGITAL-791