### PR TITLE
DIGITAL-797: sets BP_DEBUG to false explicitly in manifest.yml

### DIFF
--- a/manifest.yml
+++ b/manifest.yml
@@ -9,6 +9,7 @@ default_config: &defaults
     - https://github.com/cloudfoundry/php-buildpack.git#v4.6.28
   disk_quota: 4G
   env:
+    BP_DEBUG: false
     COMPOSER_DEV: ${COMPOSER_DEV}
     environment: ${CF_SPACE}
     LD_LIBRARY_PATH: /home/vcap/app/php/lib/


### PR DESCRIPTION
<!-- Delete any detail that does not apply to this PR! -->

## Jira ticket
[DIGITAL-797](https://gsa-standard.atlassian-us-gov-mod.net/browse/DIGITAL-797)

## Purpose

sets BP_DEBUG to false explicitly in manifest.yml.  Yep.

## Deployment and testing
### QA/Testing instructions

Should be able to see BP_DEBUG on cf env.

## Checklist for the Developer

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask for help! -->
- [x] A link to the JIRA ticket has been included above.
- [x] No merge conflicts exist with the target branch.
- [x] Automated tests have passed on this PR.
- [x] A reviewer has been designated.
- [x] Deployment and testing steps have been documented above, if applicable.

## Checklist for the Peer Reviewers

- [ ] The file changes are relevant to the task objective.
- [ ] Code is readable and includes appropriate commenting.
- [ ] Code standards and best practices are followed.
- [ ] QA/Test steps were successfully completed, if applicable.
- [ ] Applicable logs are free of errors.

<!--
Before opening this PR, make sure you’ve done whichever of these applies to you:
- Branch is up-to-date and includes latest from `develop`
- Target branch is correct
- You have ran code standards locally before assigning -`./robo.sh validate:all`
- PR is clear in both the reason it was opened and how the reviewer can confirm the work is done
-->


[DIGITAL-797]: https://gsa-standard.atlassian-us-gov-mod.net/browse/DIGITAL-797