### PR TITLE
DIGITAL-794: Remove BP_DEBUG from manifest; 'false' doesn't do what we thought

### DIFF
--- a/manifest.yml
+++ b/manifest.yml
@@ -9,7 +9,6 @@ default_config: &defaults
     - https://github.com/cloudfoundry/php-buildpack.git#v4.6.28
   disk_quota: 4G
   env:
-    BP_DEBUG: false
     COMPOSER_DEV: ${COMPOSER_DEV}
     environment: ${CF_SPACE}
     LD_LIBRARY_PATH: /home/vcap/app/php/lib/


### PR DESCRIPTION


<!-- Delete any detail that does not apply to this PR! -->

## Jira ticket

<!-- Insert a link to the Jira ticket (e.g DIGITAL-XXX). -->
<!-- Update the example below with number and paste url to ticket in the () -->
<!-- Should match the following [DIGITAL-xxx](www.pathtoticket.com) -->
[DIGITAL-794](https://gsa-standard.atlassian-us-gov-mod.net/browse/DIGITAL-794)

## Purpose

Remove `BP_DEBUG: false` from the manifest. It's being interpreted as a string (and thus true). 

[DIGITAL-794]: https://gsa-standard.atlassian-us-gov-mod.net/browse/DIGITAL-794