### PR TITLE
added google tag manager template override to add 'sandbox' attribute…

### DIFF
--- a/web/themes/custom/digital_gov/templates/google-tag-gtm-iframe.html.twig
+++ b/web/themes/custom/digital_gov/templates/google-tag-gtm-iframe.html.twig
@@ -1,0 +1,18 @@
+{#
+/**
+ * @file
+ * Overrides google_tag's GTM noscript fallback to add a sandbox attribute.
+ *
+ * The upstream template emits this iframe with no sandbox, which security
+ * scans flag as an insecure external frame. The frame renders only when
+ * scripting is disabled, and it needs nothing beyond issuing the request to
+ * Google Tag Manager, so the most restrictive sandbox value is safe: it
+ * blocks script execution and same-origin access without preventing the
+ * request that the no-script tracking fallback depends on.
+ *
+ * Available variables:
+ * - url: The Google Tag Manager iframe URL.
+ */
+#}
+<noscript><iframe sandbox src="{{ url|raw }}"
+                  height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>


### PR DESCRIPTION
… to iframe

## Jira ticket
[DIGITAL-815](https://gsa-standard.atlassian-us-gov-mod.net/browse/DIGITAL-815)

## Purpose
Fixes google tag manager iframe by securing it with `sandbox` attribute

### QA/Testing instructions
Check gtag iframe and see if it has the `sandbox` attribute.

## Checklist for the Developer

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask for help! -->
- [ ] A link to the JIRA ticket has been included above.
- [ ] No merge conflicts exist with the target branch.
- [ ] Automated tests have passed on this PR.
- [ ] A reviewer has been designated.
- [ ] Deployment and testing steps have been documented above, if applicable.

## Checklist for the Peer Reviewers

- [ ] The file changes are relevant to the task objective.
- [ ] Code is readable and includes appropriate commenting.
- [ ] Code standards and best practices are followed.
- [ ] QA/Test steps were successfully completed, if applicable.
- [ ] Applicable logs are free of errors.

<!--
Before opening this PR, make sure you’ve done whichever of these applies to you:
- Branch is up-to-date and includes latest from `develop`
- Target branch is correct
- You have ran code standards locally before assigning -`./robo.sh validate:all`
- PR is clear in both the reason it was opened and how the reviewer can confirm the work is done
-->


[DIGITAL-815]: https://gsa-standard.atlassian-us-gov-mod.net/browse/DIGITAL-815