### PR TITLE
Streamlines /resources headings and matches h1 styling to other landi…

### DIFF
--- a/web/themes/custom/digital_gov/css/new/_article.scss
+++ b/web/themes/custom/digital_gov/css/new/_article.scss
@@ -1,4 +1,5 @@
 @use "uswds-core" as *;
+@use "page-title" as *;
 
 // Article
 
@@ -21,16 +22,9 @@ article > header {
 
   // Page Titles
   h1 {
+    @include page-title-type;
     @include u-margin(0);
     @include u-margin-bottom("2px");
-    @include u-text("heavy");
-    @include u-line-height("sans", 2);
-    @include u-font("sans", "xl");
-
-    @include at-media("tablet") {
-      @include u-font("sans", "2xl");
-      @include u-line-height("sans", 2);
-    }
   }
 
   // Deck

--- a/web/themes/custom/digital_gov/css/new/_author-profile.scss
+++ b/web/themes/custom/digital_gov/css/new/_author-profile.scss
@@ -1,4 +1,5 @@
 @use "uswds-core" as *;
+@use "page-title" as *;
 
 .author-profile {
   img.profile {
@@ -8,8 +9,7 @@
   }
 
   h1 {
-    font-size: font-size("sans", "2xl");
-    font-weight: font-weight("heavy");
+    @include page-title-type;
     margin: 0;
   }
 

--- a/web/themes/custom/digital_gov/css/new/_page-head.scss
+++ b/web/themes/custom/digital_gov/css/new/_page-head.scss
@@ -1,9 +1,14 @@
 @use "uswds-core" as *;
+@use "page-title" as *;
 
 .page-head {
   @include u-padding-y(5);
 
-  h1,
+  h1 {
+    @include page-title-type;
+    margin-bottom: units(1);
+  }
+
   h2 {
     @include u-text("heavy");
     margin-bottom: units(1);

--- a/web/themes/custom/digital_gov/css/new/_page-title.scss
+++ b/web/themes/custom/digital_gov/css/new/_page-title.scss
@@ -1,0 +1,19 @@
+@use "uswds-core" as *;
+
+// Shared type treatment for page titles (h1).
+//
+// Every page title should read at the same size and weight regardless of the
+// markup it sits in. Before this existed the size depended on structure: an
+// h1 inside "main > header", "section > header" or "article > header" picked
+// up a 2xl override from _article.scss, while landing pages such as /guides
+// and /news fell through to the browser default. That produced two different
+// title sizes across the site.
+//
+// Spacing deliberately stays with each component. The contexts are not
+// equivalent -- some titles sit directly under a kicker, others under the
+// padding of .page-head -- so margins are set where that context is known.
+@mixin page-title-type {
+  @include u-font("sans", 12);
+  @include u-text("heavy");
+  @include u-line-height("sans", 2);
+}

--- a/web/themes/custom/digital_gov/css/new/_resources.scss
+++ b/web/themes/custom/digital_gov/css/new/_resources.scss
@@ -12,6 +12,15 @@
 }
 
 .dg-resource-topics-list {
+  // The topic headings are h2 so the page reads h1 > h2 with no skipped
+  // levels, but they keep the smaller "lg" type scale and 1em rhythm they
+  // had as h3 headings.
+  &__header {
+    @include u-font("sans", "lg");
+    margin-bottom: 1em;
+    margin-top: 1em;
+  }
+
   &__list-item {
     padding-bottom: units(1);
   }

--- a/web/themes/custom/digital_gov/templates/node/node--landing-page--resources.html.twig
+++ b/web/themes/custom/digital_gov/templates/node/node--landing-page--resources.html.twig
@@ -63,8 +63,11 @@
  */
 #}
 <main role="main" id="main-content">
-  <section class="grid-container-desktop">
-    <header class="page-head padding-bottom-0">
+  {# A <div> rather than a <section> on purpose: the "section > header" rule in
+     _article.scss enlarges the h1 and adds spacing that the other landing pages
+     (e.g. /guides) don't get. Keeping this a <div> matches their h1 styling. #}
+  <div class="grid-container-desktop">
+    <header class="page-head">
       <h1>{{ node.title.value }}</h1>
 
       {% if content.field_deck %}
@@ -77,5 +80,5 @@
     <div class="dg-resource-topics margin-bottom-8">
       {{ drupal_view('resource_topics_list', 'by_resource_topic') }}
     </div>
-  </section>
+  </div>
 </main>

--- a/web/themes/custom/digital_gov/templates/node/node--landing-page--resources.html.twig
+++ b/web/themes/custom/digital_gov/templates/node/node--landing-page--resources.html.twig
@@ -66,7 +66,7 @@
   {# A <div> rather than a <section> on purpose: the "section > header" rule in
      _article.scss enlarges the h1 and adds spacing that the other landing pages
      (e.g. /guides) don't get. Keeping this a <div> matches their h1 styling. #}
-  <div class="grid-container-desktop">
+  <section class="grid-container-desktop">
     <header class="page-head">
       <h1>{{ node.title.value }}</h1>
 
@@ -80,5 +80,5 @@
     <div class="dg-resource-topics margin-bottom-8">
       {{ drupal_view('resource_topics_list', 'by_resource_topic') }}
     </div>
-  </div>
+  </section>
 </main>

--- a/web/themes/custom/digital_gov/templates/node/node--landing-page--resources.html.twig
+++ b/web/themes/custom/digital_gov/templates/node/node--landing-page--resources.html.twig
@@ -63,9 +63,6 @@
  */
 #}
 <main role="main" id="main-content">
-  {# A <div> rather than a <section> on purpose: the "section > header" rule in
-     _article.scss enlarges the h1 and adds spacing that the other landing pages
-     (e.g. /guides) don't get. Keeping this a <div> matches their h1 styling. #}
   <section class="grid-container-desktop">
     <header class="page-head">
       <h1>{{ node.title.value }}</h1>

--- a/web/themes/custom/digital_gov/templates/views/views-view--resource-topics-list.html.twig
+++ b/web/themes/custom/digital_gov/templates/views/views-view--resource-topics-list.html.twig
@@ -2,7 +2,6 @@
 Wrapper around the lists grouped by resource topic to make sure
 Views doesn't add any extra containers around the lists.
 #}
-<h2 class="margin-top-0">Browse by topic</h2>
 <div class="dg-resource-topics-grid">
   {% for list in rows %}
     {{ list }}

--- a/web/themes/custom/digital_gov/templates/views/views-view-list--resource-topics-list.html.twig
+++ b/web/themes/custom/digital_gov/templates/views/views-view-list--resource-topics-list.html.twig
@@ -1,7 +1,7 @@
 <div class="dg-resource-topics-list">
-  <h3 class="dg-resource-topics-list__header">
+  <h2 class="dg-resource-topics-list__header">
     {{ title }}
-  </h3>
+  </h2>
   <ul class="dg-resource-topics-list__list usa-list usa-list--unstyled">
     {% for item in rows %}
     <li class="dg-resource-topics-list__list-item">


### PR DESCRIPTION
…ng pages

<!-- Delete any detail that does not apply to this PR! -->

## Jira ticket
[DIGITAL-805](https://gsa-standard.atlassian-us-gov-mod.net/browse/DIGITAL-805)

## Purpose
Merges the H1 and H2 headers into one to streamline content on /resources

### QA/Testing instructions
Navigate to /resources and compare to figma: https://figma-gov.com/design/Xp6OY62eZ6AQ8TLO4fsVHv/UX-improvements?node-id=100-2&p=f&t=rEyKex6WXs7Dm6y0-0

## Checklist for the Developer

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask for help! -->
- [ ] A link to the JIRA ticket has been included above.
- [ ] No merge conflicts exist with the target branch.
- [ ] Automated tests have passed on this PR.
- [ ] A reviewer has been designated.
- [ ] Deployment and testing steps have been documented above, if applicable.

## Checklist for the Peer Reviewers

- [ ] The file changes are relevant to the task objective.
- [ ] Code is readable and includes appropriate commenting.
- [ ] Code standards and best practices are followed.
- [ ] QA/Test steps were successfully completed, if applicable.
- [ ] Applicable logs are free of errors.

<!--
Before opening this PR, make sure you’ve done whichever of these applies to you:
- Branch is up-to-date and includes latest from `develop`
- Target branch is correct
- You have ran code standards locally before assigning -`./robo.sh validate:all`
- PR is clear in both the reason it was opened and how the reviewer can confirm the work is done
-->


[DIGITAL-805]: https://gsa-standard.atlassian-us-gov-mod.net/browse/DIGITAL-805